### PR TITLE
Implement access control based on client MAC address

### DIFF
--- a/minidlna.c
+++ b/minidlna.c
@@ -492,6 +492,7 @@ init(int argc, char **argv)
 	int ifaces = 0;
 	media_types types;
 	uid_t uid = 0;
+	unsigned char mac[6] = {0};
 
 	/* first check if "-f" option is used */
 	for (i=2; i<argc; i++)
@@ -568,6 +569,26 @@ init(int argc, char **argv)
 			break;
 		case UPNPFRIENDLYNAME:
 			strncpyt(friendly_name, ary_options[i].value, FRIENDLYNAME_MAX_LEN);
+			break;
+		case UPNPALLOWEDMAC:
+			memset(mac, 0, sizeof(mac));
+			if(sscanf(ary_options[i].value, "%hhx:%hhx:%hhx:%hhx:%hhx:%hhx", &mac[0], &mac[1], &mac[2], &mac[3], &mac[4], &mac[5])<6) {
+				fprintf(stderr, "Error parsing MAC address! [%s]\n", ary_options[i].value);
+				break;
+			}
+			struct allowed_mac_s *this_mac = calloc(1, sizeof(struct allowed_mac_s));
+			memcpy(this_mac->mac, mac, 6);
+			if( !allowed_macs )
+			{
+				allowed_macs = this_mac;
+			}
+			else
+			{
+				struct allowed_mac_s * all_allowed_macs = allowed_macs;
+				while( all_allowed_macs->next )
+					all_allowed_macs = all_allowed_macs->next;
+				all_allowed_macs->next = this_mac;
+			}
 			break;
 		case UPNPMEDIADIR:
 			types = ALL_MEDIA;

--- a/minidlna.conf
+++ b/minidlna.conf
@@ -61,6 +61,11 @@ notify_interval=900
 serial=12345678
 model_number=1
 
+# set this to mac addresses you want to allow
+# you can have multiple allow_mac= lines to allow multiple mac addresses
+# if you do not set this option at all, all clients are allowed
+#allowed_mac=0:12:34:56:ab:cd
+
 # specify the path to the MiniSSDPd socket
 #minissdpdsocket=/var/run/minissdpd.sock
 

--- a/minidlnatypes.h
+++ b/minidlnatypes.h
@@ -78,6 +78,11 @@ struct media_dir_s {
  	struct media_dir_s *next;
 };
 
+struct allowed_mac_s {
+	unsigned char mac[6];
+	struct allowed_mac_s * next;
+};
+
 struct album_art_name_s {
 	char *name;             /* base path */
 	uint8_t wildcard;

--- a/options.c
+++ b/options.c
@@ -65,7 +65,8 @@ static const struct {
 	{ FORCE_SORT_CRITERIA, "force_sort_criteria" },
 	{ MAX_CONNECTIONS, "max_connections" },
 	{ MERGE_MEDIA_DIRS, "merge_media_dirs" },
-	{ WIDE_LINKS, "wide_links" }
+	{ WIDE_LINKS, "wide_links" },
+	{ UPNPALLOWEDMAC, "allowed_mac" }
 };
 
 int

--- a/options.h
+++ b/options.h
@@ -58,7 +58,8 @@ enum upnpconfigoptions {
 	FORCE_SORT_CRITERIA,		/* force sorting by a given sort criteria */
 	MAX_CONNECTIONS,		/* maximum number of simultaneous connections */
 	MERGE_MEDIA_DIRS,		/* don't add an extra directory level when there are multiple media dirs */
-	WIDE_LINKS			/* allow following symlinks outside the defined media_dirs */
+	WIDE_LINKS,			/* allow following symlinks outside the defined media_dirs */
+	UPNPALLOWEDMAC			/* add mac address to list of allowed macs */
 };
 
 /* readoptionsfile()

--- a/upnpglobalvars.c
+++ b/upnpglobalvars.c
@@ -84,6 +84,7 @@ char friendly_name[FRIENDLYNAME_MAX_LEN];
 char db_path[PATH_MAX] = {'\0'};
 char log_path[PATH_MAX] = {'\0'};
 struct media_dir_s * media_dirs = NULL;
+struct allowed_mac_s *allowed_macs = NULL;
 struct album_art_name_s * album_art_names = NULL;
 short int scanning = 0;
 volatile short int quitting = 0;

--- a/upnpglobalvars.h
+++ b/upnpglobalvars.h
@@ -223,6 +223,7 @@ extern char friendly_name[];
 extern char db_path[];
 extern char log_path[];
 extern struct media_dir_s *media_dirs;
+extern struct allowed_mac_s *allowed_macs;
 extern struct album_art_name_s *album_art_names;
 extern short int scanning;
 extern volatile short int quitting;


### PR DESCRIPTION
Please find in the attachment another patch. It implements MAC-Address
based access control.

I use "git" at home. This patch is created against my "portable" version
of minidlna, see 2928850 and 2928851 in the patches tracker. I was
unable to use "cvs diff" since my other patches are not applied upstream
yet. I hope you will be able to apply this patch nevertheless. If not,
please let me know.

To use this feature, add in the config file something like

`allowed_mac=0:12:34:56:ab:cd`

(By Dominik Epple: https://sourceforge.net/p/minidlna/patches/3/)