### PR TITLE
Basic Samsung TV xxC650 support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ BASEOBJS = minidlna.o upnphttp.o upnpdescgen.o upnpsoap.o \
 
 ALLOBJS = $(BASEOBJS) $(LNXOBJS)
 
-LIBS = -lpthread -lexif -ljpeg -lsqlite3 -lavformat -lid3tag -lFLAC -lvorbis
+LIBS = -lpthread -lexif -ljpeg -lsqlite3 -lavformat -lid3tag -lFLAC -lvorbis -lffmpegthumbnailer
 #STATIC_LINKING: LIBS = -lvorbis -logg -lm -lsqlite3 -lpthread -lexif -ljpeg -lFLAC -lm -lid3tag -lz -lavformat -lavutil -lavcodec -lm
 
 TESTUPNPDESCGENOBJS = testupnpdescgen.o upnpdescgen.o

--- a/minidlna.conf
+++ b/minidlna.conf
@@ -11,10 +11,12 @@ port=8200
 #   + "A" for audio  (eg. media_dir=A,/home/jmaggard/Music)
 #   + "V" for video  (eg. media_dir=V,/home/jmaggard/Videos)
 #   + "P" for images (eg. media_dir=P,/home/jmaggard/Pictures)
-media_dir=/opt
+media_dir=V,/media/Video/Warehouse-13
+#media_dir=A,/media/Music
+#media_dir=P,/public/Daten/Fotos
 
 # set this if you want to customize the name that shows up on your clients
-#friendly_name=My DLNA Server
+friendly_name=TEST minidlna.stefan
 
 # set this if you would like to specify the directory where you want MiniDLNA to store its database and album art cache
 #db_dir=/var/cache/minidlna

--- a/scanner.c
+++ b/scanner.c
@@ -565,7 +565,8 @@ CreateDatabase(void)
 					"REF_ID TEXT DEFAULT NULL, "
 					"CLASS TEXT NOT NULL, "
 					"DETAIL_ID INTEGER DEFAULT NULL, "
-					"NAME TEXT DEFAULT NULL"
+					"NAME TEXT DEFAULT NULL, "
+                                        "BOOKMARK INTEGER DEFAULT 0" /* time position in seconds [ESamsungTV] */
 					");");
 	if( ret != SQLITE_OK )
 		goto sql_failed;

--- a/upnpdescgen.c
+++ b/upnpdescgen.c
@@ -96,6 +96,10 @@ static const char root_service[] =
 	"scpd xmlns=\"urn:schemas-upnp-org:service-1-0\"";
 static const char root_device[] = 
 	"root xmlns=\"urn:schemas-upnp-org:device-1-0\"";
+static const char root_device_samsung[] = 
+	"root xmlns=\"urn:schemas-upnp-org:device-1-0\""
+            " xmlns:sec=\"http://www.sec.co.kr/dlna\""
+            " xmlns:dlna=\"urn:schemas-dlna-org:device-1-0\"";
 
 /* root Description of the UPnP Device 
  * fixed to match UPnP_IGD_InternetGatewayDevice 1.0.pdf 
@@ -162,6 +166,75 @@ static const struct XMLElt rootDesc[] =
 	{"/serviceType", "urn:microsoft.com:service:X_MS_MediaReceiverRegistrar:1"},
 	{"/serviceId", "urn:microsoft.com:serviceId:X_MS_MediaReceiverRegistrar"},
 	{"/controlURL", X_MS_MEDIARECEIVERREGISTRAR_CONTROLURL},
+	{"/eventSubURL", X_MS_MEDIARECEIVERREGISTRAR_EVENTURL},
+	{"/SCPDURL", X_MS_MEDIARECEIVERREGISTRAR_PATH},
+	{0, 0}
+};
+
+/* root Description of the UPnP Device for Samsung TV renderers */
+static const struct XMLElt rootDescSamsung[] =
+{
+/*0*/	{root_device_samsung, INITHELPER(1,2)},
+	{"specVersion", INITHELPER(3,2)},
+	{"device", INITHELPER(5,16)},
+	{"/major", "1"},
+	{"/minor", "0"},
+	{"/deviceType", "urn:schemas-upnp-org:device:MediaServer:1"},
+	{"/friendlyName", friendly_name},	/* required */
+	{"/manufacturer", ROOTDEV_MANUFACTURER},		/* required */
+	{"/manufacturerURL", ROOTDEV_MANUFACTURERURL},	/* optional */
+	{"/modelDescription", ROOTDEV_MODELDESCRIPTION}, /* recommended */
+/*10*/	{"/modelName", ROOTDEV_MODELNAME},	/* required */
+	{"/modelNumber", modelnumber},
+	{"/modelURL", ROOTDEV_MODELURL},
+	{"/serialNumber", serialnumber},
+        {"/sec:ProductCap", "smi,DCM10,getMediaInfo.sec,getCaptionInfo.sec"},
+        {"/sec:X_ProductCap", "smi,DCM10,getMediaInfo.sec,getCaptionInfo.sec"},
+	{"/UDN", uuidvalue},	/* required */
+	{"/dlna:X_DLNADOC xmlns:dlna=\"urn:schemas-dlna-org:device-1-0\"", "DMS-1.50"},
+	{"/presentationURL", presentationurl},	/* recommended */
+	{"iconList", INITHELPER(21,4)},
+/*20*/	{"serviceList", INITHELPER(45,3)},
+	{"icon", INITHELPER(25,5)},
+	{"icon", INITHELPER(30,5)},
+	{"icon", INITHELPER(35,5)},
+	{"icon", INITHELPER(40,5)},
+	{"/mimetype", "image/png"},
+	{"/width", "48"},
+	{"/height", "48"},
+	{"/depth", "24"},
+	{"/url", "/icons/sm.png"},
+/*30*/	{"/mimetype", "image/png"},
+	{"/width", "120"},
+	{"/height", "120"},
+	{"/depth", "24"},
+	{"/url", "/icons/lrg.png"},
+	{"/mimetype", "image/jpeg"},
+	{"/width", "48"},
+	{"/height", "48"},
+	{"/depth", "24"},
+	{"/url", "/icons/sm.jpg"},
+/*40*/	{"/mimetype", "image/jpeg"},
+	{"/width", "120"},
+	{"/height", "120"},
+	{"/depth", "24"},
+	{"/url", "/icons/lrg.jpg"},
+	{"service", INITHELPER(48,5)},
+	{"service", INITHELPER(53,5)},
+	{"service", INITHELPER(58,5)},
+	{"/serviceType", "urn:schemas-upnp-org:service:ContentDirectory:1"},
+	{"/serviceId", "urn:upnp-org:serviceId:ContentDirectory"},
+/*50*/	{"/controlURL", CONTENTDIRECTORY_CONTROLURL},
+	{"/eventSubURL", CONTENTDIRECTORY_EVENTURL},
+	{"/SCPDURL", CONTENTDIRECTORY_PATH},
+	{"/serviceType", "urn:schemas-upnp-org:service:ConnectionManager:1"},
+	{"/serviceId", "urn:upnp-org:serviceId:ConnectionManager"},
+	{"/controlURL", CONNECTIONMGR_CONTROLURL},
+	{"/eventSubURL", CONNECTIONMGR_EVENTURL},
+	{"/SCPDURL", CONNECTIONMGR_PATH},
+	{"/serviceType", "urn:microsoft.com:service:X_MS_MediaReceiverRegistrar:1"},
+	{"/serviceId", "urn:microsoft.com:serviceId:X_MS_MediaReceiverRegistrar"},
+/*60*/	{"/controlURL", X_MS_MEDIARECEIVERREGISTRAR_CONTROLURL},
 	{"/eventSubURL", X_MS_MEDIARECEIVERREGISTRAR_EVENTURL},
 	{"/SCPDURL", X_MS_MEDIARECEIVERREGISTRAR_PATH},
 	{0, 0}
@@ -538,7 +611,7 @@ genXML(char * str, int * len, int * tmplen,
 	int top;
 	const char * eltname, *s;
 	char c;
-	char element[64];
+	char element[256];
 	struct {
 		unsigned short i;
 		unsigned short j;
@@ -633,6 +706,23 @@ genRootDesc(int * len)
 	/*strcpy(str, xmlver); */
 	memcpy(str, xmlver, *len + 1);
 	str = genXML(str, len, &tmplen, rootDesc);
+	str[*len] = '\0';
+	return str;
+}
+
+char *
+genRootDescSamsung(int * len)
+{
+	char * str;
+	int tmplen;
+	tmplen = 3072;
+	str = (char *)malloc(tmplen);
+	if(str == NULL)
+		return NULL;
+	* len = strlen(xmlver);
+	/*strcpy(str, xmlver); */
+	memcpy(str, xmlver, *len + 1);
+	str = genXML(str, len, &tmplen, rootDescSamsung);
 	str[*len] = '\0';
 	return str;
 }

--- a/upnpdescgen.h
+++ b/upnpdescgen.h
@@ -51,6 +51,8 @@ struct stateVar {
  * returns: NULL on error, string allocated on the heap */
 char *
 genRootDesc(int * len);
+char *
+genRootDescSamsung(int * len);
 
 /* for the two following functions */
 char *

--- a/upnphttp.c
+++ b/upnphttp.c
@@ -39,6 +39,7 @@
 #include "log.h"
 #include "sql.h"
 #include <libexif/exif-loader.h>
+#include <libffmpegthumbnailer/videothumbnailerc.h>
 #ifdef TIVO_SUPPORT
 #include "tivo_utils.h"
 #include "tivo_commands.h"
@@ -342,6 +343,10 @@ intervening space) by either an integer or the keyword "infinite". */
 			else if(strncasecmp(line, "getCaptionInfo.sec", 18)==0)
 			{
 				h->reqflags |= FLAG_CAPTION;
+			}
+			else if(strncasecmp(line, "getMediaInfo.sec", 16)==0)
+			{
+                            h->reqflags |= FLAG_MEDIA_INFO;
 			}
 		}
 next_header:
@@ -745,10 +750,10 @@ ProcessHttpQuery_upnphttp(struct upnphttp * h)
 				sendXMLdesc(h, genRootDesc);
 				friendly_name[strlen(friendly_name)-3] = '\0';
 			}
-			else
-			{
+			else if (h->req_client == ESamsungTV)
+				sendXMLdesc(h, genRootDescSamsung);
+                        else
 				sendXMLdesc(h, genRootDesc);
-			}
 		}
 		else if(strcmp(CONTENTDIRECTORY_PATH, HttpUrl) == 0)
 		{
@@ -774,6 +779,11 @@ ProcessHttpQuery_upnphttp(struct upnphttp * h)
 		else if(strncmp(HttpUrl, "/AlbumArt/", 10) == 0)
 		{
 			SendResp_albumArt(h, HttpUrl+10);
+			CloseSocket_upnphttp(h);
+		}
+		else if(strncmp(HttpUrl, "/MTA/", 5) == 0)
+		{
+			SendResp_samsung_mta_file(h, HttpUrl+5);
 			CloseSocket_upnphttp(h);
 		}
 		#ifdef TIVO_SUPPORT
@@ -1086,7 +1096,7 @@ send_file(struct upnphttp * h, int sendfd, off_t offset, off_t end_offset)
 void
 SendResp_icon(struct upnphttp * h, char * icon)
 {
-	char * header;
+        char * header = 0;
 	char * data;
 	int size, ret;
 	char mime[12];
@@ -1138,11 +1148,13 @@ SendResp_icon(struct upnphttp * h, char * icon)
 	                        "Server: " MINIDLNA_SERVER_STRING "\r\n\r\n",
 	                        mime, size, date);
 
+	DPRINTF(E_INFO, L_HTTP, "%s", header);
+
 	if( (send_data(h, header, ret, MSG_MORE) == 0) && (h->req_command != EHead) )
 	{
 		send_data(h, data, size, 0);
 	}
-	free(header);
+        free(header);
 }
 
 void
@@ -1200,20 +1212,21 @@ SendResp_albumArt(struct upnphttp * h, char * object)
 				"Connection: close\r\n"
 				"Date: %s\r\n"
 				"EXT:\r\n"
-				"realTimeInfo.dlna.org: DLNA.ORG_TLAG=*\r\n"
 				"contentFeatures.dlna.org: DLNA.ORG_PN=JPEG_TN\r\n"
 				"Server: " MINIDLNA_SERVER_STRING "\r\n",
 				size, date);
 
-		if( h->reqflags & FLAG_XFERBACKGROUND )
-		{
-			strcat(header, "transferMode.dlna.org: Background\r\n\r\n");
-		}
-		else //if( h->reqflags & FLAG_XFERINTERACTIVE )
-		{
-			strcat(header, "transferMode.dlna.org: Interactive\r\n\r\n");
-		}
+		if( h->reqflags & FLAG_REALTIMEINFO )
+			strcat(header, "realTimeInfo.dlna.org: DLNA.ORG_TLAG=*\r\n");
 
+		if( h->reqflags & FLAG_XFERBACKGROUND )
+			strcat(header, "transferMode.dlna.org: Background\r\n");
+		else //if( h->reqflags & FLAG_XFERINTERACTIVE )
+			strcat(header, "transferMode.dlna.org: Interactive\r\n");
+
+                DPRINTF(E_INFO, L_HTTP, "%s", header);
+
+                strcat(header, "\r\n");
 
 		if( (send_data(h, header, strlen(header), MSG_MORE) == 0) && (h->req_command != EHead) && (sendfh > 0) )
 		{
@@ -1265,14 +1278,24 @@ SendResp_caption(struct upnphttp * h, char * object)
 	lseek(sendfh, 0, SEEK_SET);
 
 	ret = snprintf(header, sizeof(header), "HTTP/1.1 200 OK\r\n"
+/*	                                       "Server: Samsung HTTP streaming server\r\n" */
+	                                       "Server: " MINIDLNA_SERVER_STRING "\r\n"
 	                                       "Content-Type: smi/caption\r\n"
 	                                       "Content-Length: %jd\r\n"
-	                                       "Connection: close\r\n"
+	                                       "Cache-Control: no-cache\r\n"
+                                               "contentFeatures.dlna.org: DLNA.ORG_OP=00;DLNA.ORG_CI=0;\r\n"
+/*	                                       "Connection: close\r\n" */
 	                                       "Date: %s\r\n"
 	                                       "EXT:\r\n"
-	                                       "Server: " MINIDLNA_SERVER_STRING "\r\n\r\n",
-	                                       size, date);
+                                               , size, date);
 
+	if( h->reqflags & FLAG_XFERBACKGROUND )
+		strcat(header, "transferMode.dlna.org:Background\r\n");
+
+	DPRINTF(E_INFO, L_HTTP, "%s", header);
+
+	strcat(header, "\r\n");
+	
 	if( (send_data(h, header, ret, MSG_MORE) == 0) && (h->req_command != EHead) && (sendfh > 0) )
 	{
 		send_file(h, sendfh, offset, size);
@@ -1339,19 +1362,25 @@ SendResp_thumbnail(struct upnphttp * h, char * object)
 				"Connection: close\r\n"
 				"Date: %s\r\n"
 				"EXT:\r\n"
-				"realTimeInfo.dlna.org: DLNA.ORG_TLAG=*\r\n"
 			 	"contentFeatures.dlna.org: DLNA.ORG_PN=JPEG_TN\r\n"
 				"Server: " MINIDLNA_SERVER_STRING "\r\n",
 				ed->size, date);
 
+		if( h->reqflags & FLAG_REALTIMEINFO )
+			strcat(header, "realTimeInfo.dlna.org: DLNA.ORG_TLAG=*\r\n");
+
 		if( h->reqflags & FLAG_XFERBACKGROUND )
 		{
-			strcat(header, "transferMode.dlna.org: Background\r\n\r\n");
+			strcat(header, "transferMode.dlna.org: Background\r\n");
 		}
 		else //if( h->reqflags & FLAG_XFERINTERACTIVE )
 		{
-			strcat(header, "transferMode.dlna.org: Interactive\r\n\r\n");
+			strcat(header, "transferMode.dlna.org: Interactive\r\n");
 		}
+
+                DPRINTF(E_INFO, L_HTTP, "%s", header);
+
+                strcat(header, "\r\n");
 
 		if( (send_data(h, header, strlen(header), MSG_MORE) == 0) && (h->req_command != EHead) )
 		{
@@ -1489,10 +1518,12 @@ SendResp_resizedimg(struct upnphttp * h, char * object)
 	                                     "Connection: close\r\n"
 	                                     "Date: %s\r\n"
 	                                     "EXT:\r\n"
-	                                     "realTimeInfo.dlna.org: DLNA.ORG_TLAG=*\r\n"
 	                                     "contentFeatures.dlna.org: DLNA.ORG_PN=JPEG_%s;DLNA.ORG_CI=1\r\n"
 	                                     "Server: " MINIDLNA_SERVER_STRING "\r\n",
 	                                     date, dlna_pn);
+	if( h->reqflags & FLAG_REALTIMEINFO )
+		strcat(header, "realTimeInfo.dlna.org: DLNA.ORG_TLAG=*\r\n");
+
 	if( h->reqflags & FLAG_XFERINTERACTIVE )
 	{
 		strcat(header, "transferMode.dlna.org: Interactive\r\n");
@@ -1550,6 +1581,8 @@ SendResp_resizedimg(struct upnphttp * h, char * object)
 		strcat(header, str_buf);
 	}
 
+	DPRINTF(E_INFO, L_HTTP, "%s", header);
+
 	if( (send_data(h, header, strlen(header), 0) == 0) && (h->req_command != EHead) )
 	{
 		if( chunked )
@@ -1600,7 +1633,7 @@ SendResp_dlnafile(struct upnphttp * h, char * object)
 	off_t total, offset, size;
 	sqlite_int64 id;
 	int sendfh;
-	static struct { sqlite_int64 id; char path[PATH_MAX]; char mime[32]; char dlna[64]; } last_file = { 0 };
+	static struct { sqlite_int64 id; char path[PATH_MAX]; char mime[32]; char dlna[128]; char duration[32]; } last_file = { 0 };
 #if USE_FORK
 	pid_t newpid = 0;
 #endif
@@ -1608,7 +1641,7 @@ SendResp_dlnafile(struct upnphttp * h, char * object)
 	id = strtoll(object, NULL, 10);
 	if( id != last_file.id )
 	{
-		sprintf(sql_buf, "SELECT PATH, MIME, DLNA_PN from DETAILS where ID = '%lld'", id);
+		sprintf(sql_buf, "SELECT PATH, MIME, DLNA_PN, DURATION from DETAILS where ID = '%lld'", id);
 		ret = sql_get_table(db, sql_buf, &result, &rows, NULL);
 		if( (ret != SQLITE_OK) )
 		{
@@ -1625,10 +1658,10 @@ SendResp_dlnafile(struct upnphttp * h, char * object)
 		}
 		/* Cache the result */
 		last_file.id = id;
-		strncpy(last_file.path, result[3], sizeof(last_file.path)-1);
-		if( result[4] )
+		strncpy(last_file.path, result[4], sizeof(last_file.path)-1);
+		if( result[5] )
 		{
-			strncpy(last_file.mime, result[4], sizeof(last_file.mime)-1);
+			strncpy(last_file.mime, result[5], sizeof(last_file.mime)-1);
 			/* From what I read, Samsung TV's expect a [wrong] MIME type of x-mkv. */
 			if( h->req_client == ESamsungTV )
 			{
@@ -1640,12 +1673,16 @@ SendResp_dlnafile(struct upnphttp * h, char * object)
 		{
 			last_file.mime[0] = '\0';
 		}
-		if( result[5] )
-			snprintf(last_file.dlna, sizeof(last_file.dlna), "DLNA.ORG_PN=%s", result[5]);
+		if( result[6] )
+			snprintf(last_file.dlna, sizeof(last_file.dlna), "DLNA.ORG_PN=%s", result[6]);
 		else if( h->reqflags & FLAG_DLNA )
 			strcpy(last_file.dlna, dlna_no_conv);
 		else
 			last_file.dlna[0] = '\0';
+
+                if( result[7] )
+                    strncpy(last_file.duration, result[7], sizeof(last_file.duration)-1);
+
 		sqlite3_free_table(result);
 	}
 #if USE_FORK
@@ -1779,15 +1816,39 @@ SendResp_dlnafile(struct upnphttp * h, char * object)
 		}
 	}
 
+	if( last_file.duration && h->reqflags & FLAG_MEDIA_INFO ) {
+            int dur = atoi(rindex(last_file.duration, '.')+1) +
+                (1000*atoi(rindex(last_file.duration, ':')+1)) +
+                (60000*atoi(rindex(last_file.duration, ':')-2)) +
+                (3600000*atoi(last_file.duration));
+            sprintf(hdr_buf, "MediaInfo.sec: SEC_Duration=%d\r\n", dur);
+            strcat(header, hdr_buf);
+	}
+
+        /* Special Samsung DLNA flags */
+        if( h->req_client == ESamsungTV ) {
+		if( strncmp(last_file.mime, "image", 5) == 0 )
+                    strcat(last_file.dlna, ";DLNA.ORG_FLAGS=00D00000000000000000000000000000");
+                else if (strncmp(last_file.mime, "video", 5) == 0)
+                    strcat(last_file.dlna, ";DLNA.ORG_FLAGS=01500000000000000000000000000000");
+        }
+
 	sprintf(hdr_buf, "Accept-Ranges: bytes\r\n"
 			 "Connection: close\r\n"
 			 "Date: %s\r\n"
 			 "EXT:\r\n"
-	                 "realTimeInfo.dlna.org: DLNA.ORG_TLAG=*\r\n"
-			 "contentFeatures.dlna.org: %s\r\n"
-			 "Server: " MINIDLNA_SERVER_STRING "\r\n\r\n",
+			 "contentFeatures.dlna.org:%s\r\n"
+			 "Server: " MINIDLNA_SERVER_STRING "\r\n",
 			 date, last_file.dlna);
+
 	strcat(header, hdr_buf);
+
+	if( h->reqflags & FLAG_REALTIMEINFO )
+            strcat(header, "realTimeInfo.dlna.org: DLNA.ORG_TLAG=*\r\n");
+
+	DPRINTF(E_INFO, L_HTTP, "%s", header);
+
+	strcat(header, "\r\n");
 
 	if( (send_data(h, header, strlen(header), MSG_MORE) == 0) && (h->req_command != EHead) && (sendfh > 0) )
 	{
@@ -1801,4 +1862,238 @@ SendResp_dlnafile(struct upnphttp * h, char * object)
 		_exit(0);
 #endif
 	return;
+}
+
+/* encode 6 bit to base64 char */
+static char encode_base64(unsigned char c)
+{
+  if (c < 26)
+      return 'A' + c;
+  if (c < 52)
+      return 'a' + (c-26);
+  if (c < 62)
+      return '0' + (c-52);
+  if (c == 62)
+      return '+';
+
+  /* 63 */
+  return '/';
+}
+
+void
+adjust_buffer(char** buffer, int* length)
+{
+    *length += *length; /* double buffer size */
+    *buffer = realloc(*buffer, *length+1); /* get one for the terminating zero */
+}
+
+/* append data to buffer, if necessary get more memory and rebase current ptr */
+void
+add_to_buffer(char** buffer, int* length, char** ptr, const char* data, int datalen)
+{
+    if (*ptr - *buffer > *length) {
+        *ptr -= (int)*buffer;
+        adjust_buffer(buffer, length);
+        *ptr += (int)*buffer; /* rebase ptr */
+    }
+    memcpy(*ptr, data, datalen);
+    *ptr += datalen;
+}
+
+char*
+generate_mta_file(char* path, int duration)
+{
+    static const char mta_header[] =
+        "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\r\n"
+        "<SEC:SECMeta xsi:schemaLocation=\"urn:samsung:metadata:2009 Video_Metadata_v1.0.xsd\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns:SEC=\"urn:samsung:metadata:2009\">\r\n"
+        "<SpecVersion>1.0</SpecVersion>\r\n"
+        "<MediaInformation>\r\n"
+        "<VideoLocator>\r\n"
+        "<MediaUri>file://samsung_content.con</MediaUri>\r\n"
+        "</VideoLocator>\r\n"
+        "</MediaInformation>\r\n"
+        "<ContentInformation>\r\n"
+        "<Chaptering>\r\n"
+        ;
+    static const char mta_chapter_header[] =
+        "<ChapterSegment>\r\n"
+        "<KeyFrame>\r\n"
+        "<InlineMedia>"
+        ;
+    static const char mta_chapter_closing[] =
+        "</InlineMedia>\r\n"
+        "</KeyFrame>\r\n"
+        "<MediaPosition>\r\n"
+        "<MediaTime timePoint=\"%d\"/>\r\n"
+        "</MediaPosition>\r\n"
+        "</ChapterSegment>\r\n"
+        ;
+    static const char mta_closing[] =
+        "</Chaptering>\r\n"
+        "</ContentInformation>\r\n"
+        "</SEC:SECMeta>\r\n"
+        ;
+
+    char* buffer = 0;
+    if (ends_with(path, ".avi") || ends_with(path, ".mkv") || ends_with(path, ".mpg")) {
+        video_thumbnailer* vt=0;
+        int percentage;
+        int length = 100*1024;
+        char* ptr;
+
+        buffer = malloc(length+1); /* one for the terminating zero */
+        if (!buffer)
+            return ""; /* fail (empty string!) */
+
+        ptr = buffer;
+        add_to_buffer(&buffer, &length, &ptr, mta_header, strlen(mta_header));
+
+        vt = video_thumbnailer_create();
+        vt->thumbnail_image_type = Jpeg;
+        /* Samsung accepts exactly 5 positions nothing more, nothing less*/
+        for(percentage = 16; percentage < 95; percentage+=16) {
+            int rc;
+            image_data* imgdata = video_thumbnailer_create_image_data();
+
+            add_to_buffer(&buffer, &length, &ptr, mta_chapter_header, strlen(mta_chapter_header));
+
+            vt->seek_percentage = percentage;
+            DPRINTF(E_DEBUG, L_METADATA, "generate MTA file for '%s'\n", path);
+
+            rc = video_thumbnailer_generate_thumbnail_to_buffer(vt, path, imgdata);
+            DPRINTF(E_DEBUG, L_METADATA, "rc: %d, size=%d\n", rc, imgdata->image_data_size);
+
+            if (!rc && imgdata->image_data_size) {
+                int idx;
+                unsigned char* src = imgdata->image_data_ptr;
+                int size = imgdata->image_data_size;
+                /* base 64 encoding of the image */
+                for(idx=0; idx < size; idx += 3) {
+                    unsigned char r1=0, r2=0, r3=0, b1=0, b2=0, b3=0, b4=0;
+
+                    /* get 3 byte / 24 bit */
+                    r1 = src[idx];
+                    
+                    if (idx+1 < size)
+                        r2 = src[idx+1];
+
+                    if (idx+2 < size)
+                        r3 = src[idx+2];
+
+                    /* spread to 4 6-bit parts */
+                    b1 = r1 >> 2;
+                    b2 = ((r1 & 0x3) << 4) | (r2 >> 4);
+                    b3 = ((r2 & 0xf) << 2) | (r3 >> 6);
+                    b4 = r3 & 0x3f;
+
+                    /* encode 6-bit output */
+                    *ptr++ = encode_base64(b1);
+                    *ptr++ = encode_base64(b2);
+
+                    if (idx+1 < size)
+                        *ptr++ = encode_base64(b3);
+                    else
+                        *ptr++ = '=';
+
+                    if (idx+2 < size)
+                        *ptr++ = encode_base64(b4);
+                    else
+                        *ptr++ = '=';
+
+                    /* check buffer size, realloc if necessary */
+                    if (ptr+2 > buffer+length) {
+                        ptr -= (int)buffer;
+                        adjust_buffer(&buffer, &length);
+                        ptr += (int)buffer; /* rebase ptr */
+                    }
+                }
+            }
+            video_thumbnailer_destroy_image_data(imgdata);
+
+            /* add time code for this thumbnail */
+            {
+                char tmp[sizeof(mta_chapter_closing)+10];
+                int pos = (duration * percentage) / 100;
+                snprintf(tmp, sizeof(mta_chapter_closing)+10, mta_chapter_closing, pos);
+                add_to_buffer(&buffer, &length, &ptr, tmp, strlen(tmp));
+            }
+        }
+        video_thumbnailer_destroy(vt);
+
+        add_to_buffer(&buffer, &length, &ptr, mta_closing, strlen(mta_closing));
+        *ptr = 0; /* terminate buffer! */
+    }
+    return buffer;
+}
+
+void
+SendResp_samsung_mta_file(struct upnphttp * h, char * object)
+{
+    char header[1500];
+    char sql_buf[256];
+    char **result;
+    int rows = 0;
+    char *path;
+    int duration = 0;
+    char *dash;
+
+    memset(header, 0, 1500);
+
+    dash = strchr(object, '.');
+    if( dash )
+        *dash = '\0';
+    sprintf(sql_buf, "select PATH, DURATION from DETAILS where ID = '%s';", object);
+    DPRINTF(E_DEBUG, L_HTTP, "Get MTA file SQL: %s\n", sql_buf);
+    sql_get_table(db, sql_buf, &result, &rows, NULL);
+    if( !rows )
+    {
+        DPRINTF(E_WARN, L_HTTP, "Object ID %s not found, responding ERROR 404\n", object);
+        Send404(h);
+        goto error;
+    }
+    path = result[2];
+    duration = (   1 * atoi(rindex(result[3], ':')+1)) +
+               (  60 * atoi(rindex(result[3], ':')-2)) +
+               (3600 * atoi(result[3]));
+    DPRINTF(E_INFO, L_HTTP, "Generating MTA file for object (ID='%s') on [%s], duration=%d\n", object, path, duration);
+
+    if( access(path, F_OK) == 0 ) {
+        time_t curtime = time(NULL);
+        char date[30];
+
+        char* body = generate_mta_file(path, duration);
+        int size = strlen(body);
+
+        strftime(date, 30,"%a, %d %b %Y %H:%M:%S GMT" , gmtime(&curtime));
+        sprintf(header, "HTTP/1.1 200 OK\r\n"
+                "Content-Type: image/jpeg\r\n"
+                "Content-Length: %d\r\n"
+                "Connection: close\r\n"
+                "Date: %s\r\n"
+                "EXT:\r\n"
+                "contentFeatures.dlna.org:DLNA.ORG_OP=00;DLNA.ORG_CI=0;\r\n"
+                "Server: " MINIDLNA_SERVER_STRING "\r\n",
+                size, date);
+
+        if( h->reqflags & FLAG_REALTIMEINFO )
+            strcat(header, "realTimeInfo.dlna.org: DLNA.ORG_TLAG=*\r\n");
+
+        if( h->reqflags & FLAG_XFERBACKGROUND )
+            strcat(header, "transferMode.dlna.org: Background\r\n");
+        else
+            strcat(header, "transferMode.dlna.org: Interactive\r\n");
+
+        DPRINTF(E_INFO, L_HTTP, "%s", header);
+
+        strcat(header, "\r\n");
+
+        if( (send_data(h, header, strlen(header), MSG_MORE) == 0) && h->req_command != EHead )
+        {
+            DPRINTF(E_INFO, L_HTTP, "%s", body);
+            send_data(h, body, size, 0);
+        }
+        free(body);
+    }
+  error:
+    sqlite3_free_table(result);
 }

--- a/upnphttp.h
+++ b/upnphttp.h
@@ -87,6 +87,7 @@ struct upnphttp {
 #define FLAG_MIME_AVI_AVI       0x00400000
 #define FLAG_MIME_FLAC_FLAC     0x00800000
 #define FLAG_NO_RESIZE          0x01000000
+#define FLAG_MEDIA_INFO         0x02000000
 
 /* New_upnphttp() */
 struct upnphttp *
@@ -147,5 +148,8 @@ SendResp_thumbnail(struct upnphttp *, char * url);
  * send the actual file data for a UPnP-A/V or DLNA request. */
 void
 SendResp_dlnafile(struct upnphttp *, char * url);
+void
+SendResp_samsung_mta_file(struct upnphttp * h, char * object);
+
 #endif
 

--- a/upnpsoap.c
+++ b/upnpsoap.c
@@ -296,6 +296,12 @@ mime_to_ext(const char * mime, char * buf)
 #define FILTER_UPNP_GENRE                        0x00020000
 #define FILTER_UPNP_ORIGINALTRACKNUMBER          0x00040000
 #define FILTER_UPNP_SEARCHCLASS                  0x00080000
+#define FILTER_SEC				 0x00100000
+#define FILTER_SEC_CAPTION_INFO			 0x00200000
+#define FILTER_SEC_CAPTION_INFO_EX		 0x00400000
+#define FILTER_SEC_DCM_INFO			 0x00800000
+#define FILTER_SEC_META_FILE_INFO		 0x01000000
+#define FILTER_PARENT_ID			 0x02000000
 
 static u_int32_t
 set_filter_flags(char * filter)
@@ -411,6 +417,30 @@ set_filter_flags(char * filter)
 			flags |= FILTER_RES;
 			flags |= FILTER_RES_SIZE;
 		}
+		else if( strcmp(item, "sec:CaptionInfo") == 0)
+		{
+			flags |= FILTER_SEC;
+			flags |= FILTER_SEC_CAPTION_INFO;
+		}
+		else if( strcmp(item, "sec:CaptionInfoEx") == 0)
+		{
+			flags |= FILTER_SEC;
+			flags |= FILTER_SEC_CAPTION_INFO_EX;
+		}
+		else if( strcmp(item, "sec:dcmInfo") == 0)
+		{
+			flags |= FILTER_SEC;
+			flags |= FILTER_SEC_DCM_INFO;
+		}
+		else if( strcmp(item, "sec:MetaFileInfo") == 0)
+		{
+			flags |= FILTER_SEC;
+			flags |= FILTER_SEC_META_FILE_INFO;
+		}
+		else if( strcmp(item, "@parentID") == 0 )
+		{
+			flags |= FILTER_PARENT_ID;
+		}
 		item = strtok_r(NULL, ",", &saveptr);
 	}
 
@@ -522,7 +552,7 @@ static void add_resized_res(int srcw, int srch, int reqw, int reqh, char *dlna_p
 		memcpy(passed_args->resp+passed_args->size, &str_buf, ret+1);
 		passed_args->size += ret;
 	}
-	ret = sprintf(str_buf, "protocolInfo=\"http-get:*:image/jpeg:DLNA.ORG_PN=%s;DLNA.ORG_CI=1\"&gt;"
+	ret = sprintf(str_buf, "protocolInfo=\"http-get:*:image/jpeg:DLNA.ORG_PN=%s;DLNA.ORG_CI=1;DLNA.ORG_FLAGS=01500000000000000000000000000000\"&gt;"
 	                       "http://%s:%d/Resized/%s.jpg?width=%d,height=%d"
 	                       "&lt;/res&gt;",
 	                       dlna_pn, lan_addr[0].str, runtime_vars.port,
@@ -534,7 +564,7 @@ static void add_resized_res(int srcw, int srch, int reqw, int reqh, char *dlna_p
 #define SELECT_COLUMNS "SELECT o.OBJECT_ID, o.PARENT_ID, o.REF_ID, o.DETAIL_ID, o.CLASS," \
                        " d.SIZE, d.TITLE, d.DURATION, d.BITRATE, d.SAMPLERATE, d.ARTIST," \
                        " d.ALBUM, d.GENRE, d.COMMENT, d.CHANNELS, d.TRACK, d.DATE, d.RESOLUTION," \
-                       " d.THUMBNAIL, d.CREATOR, d.DLNA_PN, d.MIME, d.ALBUM_ART, d.DISC "
+                       " d.THUMBNAIL, d.CREATOR, d.DLNA_PN, d.MIME, d.ALBUM_ART, d.DISC, c.PATH "
 
 static int
 callback(void *args, int argc, char **argv, char **azColName)
@@ -543,7 +573,7 @@ callback(void *args, int argc, char **argv, char **azColName)
 	char *id = argv[0], *parent = argv[1], *refID = argv[2], *detailID = argv[3], *class = argv[4], *size = argv[5], *title = argv[6],
 	     *duration = argv[7], *bitrate = argv[8], *sampleFrequency = argv[9], *artist = argv[10], *album = argv[11],
 	     *genre = argv[12], *comment = argv[13], *nrAudioChannels = argv[14], *track = argv[15], *date = argv[16], *resolution = argv[17],
-	     *tn = argv[18], *creator = argv[19], *dlna_pn = argv[20], *mime = argv[21], *album_art = argv[22];
+	     *tn = argv[18], *creator = argv[19], *dlna_pn = argv[20], *mime = argv[21], *album_art = argv[22], *disc = argv[23], *caption_path = argv[24];
 	char dlna_buf[96];
 	char ext[5];
 	char str_buf[512];
@@ -580,13 +610,23 @@ callback(void *args, int argc, char **argv, char **azColName)
 
 	if( dlna_pn )
 		sprintf(dlna_buf, "DLNA.ORG_PN=%s", dlna_pn);
-	else if( passed_args->flags & FLAG_DLNA )
+	else if( passed_args->flags & FLAG_DLNA ) {
 		strcpy(dlna_buf, dlna_no_conv);
+                if (passed_args->client == ESamsungTV && mime && *mime == 'v')
+                    strcat(dlna_buf, ";DLNA.ORG_FLAGS=01500000000000000000000000000000");
+        }
 	else
 		strcpy(dlna_buf, "*");
-
+#if 0
+        if ( date && passed_args->client == ESamsungTV )
+            *rindex(date, 'T') = 0;
+#endif
 	if( strncmp(class, "item", 4) == 0 )
 	{
+#if 0
+            if ( duration && passed_args->client == ESamsungTV )
+                *rindex(duration, '.') = 0;
+#endif
 		/* We may need special handling for certain MIME types */
 		if( *mime == 'v' )
 		{
@@ -600,7 +640,7 @@ callback(void *args, int argc, char **argv, char **azColName)
 						strcpy(mime+6, "avi");
 				}
 			}
-			else if( passed_args->flags & FLAG_MIME_AVI_AVI )
+			else if( passed_args->flags & FLAG_MIME_AVI_AVI && passed_args->client != ESamsungTV)
 			{
 				if( strcmp(mime, "video/x-msvideo") == 0 )
 				{
@@ -663,6 +703,31 @@ callback(void *args, int argc, char **argv, char **azColName)
 			memcpy(passed_args->resp+passed_args->size, &str_buf, ret+1);
 			passed_args->size += ret;
 		}
+		if( passed_args->filter & FILTER_SEC_CAPTION_INFO_EX) {
+                    /* Get bookmark */
+                    int posSecond = sql_get_int_field(db, "SELECT BOOKMARK from OBJECTS where OBJECT_ID = '%s';", id);
+                    ret = sprintf(str_buf, "&lt;sec:dcmInfo&gt;CREATIONDATE=0,FOLDER=%s,BM=%d&lt;/sec:dcmInfo&gt;", parent, posSecond);
+                    memcpy(passed_args->resp+passed_args->size, &str_buf, ret+1);
+                    passed_args->size += ret;
+		}
+ 		if( caption_path && passed_args->filter & FILTER_SEC_CAPTION_INFO_EX) {
+			char * caption_ext;
+			caption_ext = strrchr(caption_path, '.');
+			if( caption_ext ) {
+				++caption_ext;
+				ret = sprintf(str_buf, "&lt;sec:CaptionInfoEx sec:type=&quot;%s&quot;&gt;http://%s:%d/Captions/%s.%s&lt;/sec:CaptionInfoEx&gt;",
+					 caption_ext, lan_addr[0].str, runtime_vars.port, detailID, caption_ext);
+			        memcpy(passed_args->resp+passed_args->size, &str_buf, ret+1);
+			        passed_args->size += ret;
+			}
+		}
+		if( passed_args->filter & FILTER_SEC_META_FILE_INFO) {
+                    /* Advertise chapter data */
+			ret = sprintf(str_buf, "&lt;sec:MetaFileInfo sec:type=&quot;mta&quot;&gt;http://%s:%d/MTA/%s.mta&lt;/sec:MetaFileInfo&gt;",
+                                      lan_addr[0].str, runtime_vars.port, detailID);
+			memcpy(passed_args->resp+passed_args->size, &str_buf, ret+1);
+			passed_args->size += ret;
+		}
 		if( artist && (passed_args->filter & FILTER_UPNP_ARTIST) ) {
 			ret = snprintf(str_buf, 512, "&lt;upnp:artist&gt;%s&lt;/upnp:artist&gt;", artist);
 			memcpy(passed_args->resp+passed_args->size, &str_buf, ret+1);
@@ -686,82 +751,56 @@ callback(void *args, int argc, char **argv, char **azColName)
 			memcpy(passed_args->resp+passed_args->size, &str_buf, ret+1);
 			passed_args->size += ret;
 		}
-		if( album_art && atoi(album_art) )
-		{
-			/* Video and audio album art is handled differently */
-			if( *mime == 'v' && (passed_args->filter & FILTER_RES) && (passed_args->client != EXbox) ) {
-				ret = sprintf(str_buf, "&lt;res protocolInfo=\"http-get:*:image/jpeg:DLNA.ORG_PN=JPEG_TN\"&gt;"
-				                       "http://%s:%d/AlbumArt/%s-%s.jpg"
-				                       "&lt;/res&gt;",
-				                       lan_addr[0].str, runtime_vars.port, album_art, detailID);
-				memcpy(passed_args->resp+passed_args->size, &str_buf, ret+1);
-				passed_args->size += ret;
-			}
-			else if( passed_args->filter & FILTER_UPNP_ALBUMARTURI ) {
-				ret = sprintf(str_buf, "&lt;upnp:albumArtURI ");
-				memcpy(passed_args->resp+passed_args->size, &str_buf, ret+1);
-				passed_args->size += ret;
-				if( passed_args->filter & FILTER_UPNP_ALBUMARTURI_DLNA_PROFILEID ) {
-					ret = sprintf(str_buf, "dlna:profileID=\"%s\" xmlns:dlna=\"urn:schemas-dlna-org:metadata-1-0/\"", "JPEG_TN");
-					memcpy(passed_args->resp+passed_args->size, &str_buf, ret+1);
-					passed_args->size += ret;
-				}
-				ret = sprintf(str_buf, "&gt;http://%s:%d/AlbumArt/%s-%s.jpg&lt;/upnp:albumArtURI&gt;",
-						 lan_addr[0].str, runtime_vars.port, album_art, detailID);
-				memcpy(passed_args->resp+passed_args->size, &str_buf, ret+1);
-				passed_args->size += ret;
-			}
-		}
+                /* <res>-tag for actual item */
 		if( passed_args->filter & FILTER_RES ) {
 			mime_to_ext(mime, ext);
 			if( (passed_args->client == EFreeBox) && tn && atoi(tn) ) {
 				ret = sprintf(str_buf, "&lt;res protocolInfo=\"http-get:*:%s:%s\"&gt;"
 				                       "http://%s:%d/Thumbnails/%s.jpg"
 				                       "&lt;/res&gt;",
-				                       mime, "DLNA.ORG_PN=JPEG_TN", lan_addr[0].str, runtime_vars.port, detailID);
+				                       mime, "DLNA.ORG_PN=JPEG_TN;DLNA.ORG_CI=1", lan_addr[0].str, runtime_vars.port, detailID);
 				memcpy(passed_args->resp+passed_args->size, &str_buf, ret+1);
 				passed_args->size += ret;
 			}
-			ret = sprintf(str_buf, "&lt;res ");
+			ret = sprintf(str_buf, "&lt;res protocolInfo=\"http-get:*:%s:%s\"", mime, dlna_buf);
 			memcpy(passed_args->resp+passed_args->size, &str_buf, ret+1);
 			passed_args->size += ret;
 			if( size && (passed_args->filter & FILTER_RES_SIZE) ) {
-				ret = sprintf(str_buf, "size=\"%s\" ", size);
+				ret = sprintf(str_buf, " size=\"%s\"", size);
+				memcpy(passed_args->resp+passed_args->size, &str_buf, ret+1);
+				passed_args->size += ret;
+			}
+			if( resolution && (passed_args->filter & FILTER_RES_RESOLUTION) ) {
+				ret = sprintf(str_buf, " resolution=\"%s\"", resolution);
 				memcpy(passed_args->resp+passed_args->size, &str_buf, ret+1);
 				passed_args->size += ret;
 			}
 			if( duration && (passed_args->filter & FILTER_RES_DURATION) ) {
-				ret = sprintf(str_buf, "duration=\"%s\" ", duration);
+                                ret = sprintf(str_buf, " duration=\"%s\"", duration);
 				memcpy(passed_args->resp+passed_args->size, &str_buf, ret+1);
 				passed_args->size += ret;
 			}
 			if( bitrate && (passed_args->filter & FILTER_RES_BITRATE) ) {
 				if( passed_args->client == EXbox )
-					ret = sprintf(str_buf, "bitrate=\"%d\" ", atoi(bitrate)/1024);
+					ret = sprintf(str_buf, " bitrate=\"%d\"", atoi(bitrate)/1024);
 				else
-					ret = sprintf(str_buf, "bitrate=\"%s\" ", bitrate);
+					ret = sprintf(str_buf, " bitrate=\"%s\"", bitrate);
 				memcpy(passed_args->resp+passed_args->size, &str_buf, ret+1);
 				passed_args->size += ret;
 			}
 			if( sampleFrequency && (passed_args->filter & FILTER_RES_SAMPLEFREQUENCY) ) {
-				ret = sprintf(str_buf, "sampleFrequency=\"%s\" ", sampleFrequency);
+				ret = sprintf(str_buf, " sampleFrequency=\"%s\"", sampleFrequency);
 				memcpy(passed_args->resp+passed_args->size, &str_buf, ret+1);
 				passed_args->size += ret;
 			}
 			if( nrAudioChannels && (passed_args->filter & FILTER_RES_NRAUDIOCHANNELS) ) {
-				ret = sprintf(str_buf, "nrAudioChannels=\"%s\" ", nrAudioChannels);
+				ret = sprintf(str_buf, " nrAudioChannels=\"%s\"", nrAudioChannels);
 				memcpy(passed_args->resp+passed_args->size, &str_buf, ret+1);
 				passed_args->size += ret;
 			}
-			if( resolution && (passed_args->filter & FILTER_RES_RESOLUTION) ) {
-				ret = sprintf(str_buf, "resolution=\"%s\" ", resolution);
-				memcpy(passed_args->resp+passed_args->size, &str_buf, ret+1);
-				passed_args->size += ret;
-			}
-			ret = sprintf(str_buf, "protocolInfo=\"http-get:*:%s:%s\"&gt;"
-			                       "http://%s:%d/MediaItems/%s.%s"
+			ret = sprintf(str_buf, "&gt;http://%s:%d/MediaItems/%s.%s"
 			                       "&lt;/res&gt;",
-			                       mime, dlna_buf, lan_addr[0].str, runtime_vars.port, detailID, ext);
+			                       lan_addr[0].str, runtime_vars.port, detailID, ext);
 			memcpy(passed_args->resp+passed_args->size, &str_buf, ret+1);
 			passed_args->size += ret;
 			if( (*mime == 'i') && (passed_args->client != EFreeBox) ) {
@@ -779,10 +818,46 @@ callback(void *args, int argc, char **argv, char **azColName)
 					ret = sprintf(str_buf, "&lt;res protocolInfo=\"http-get:*:%s:%s\"&gt;"
 					                       "http://%s:%d/Thumbnails/%s.jpg"
 					                       "&lt;/res&gt;",
-					                       mime, "DLNA.ORG_PN=JPEG_TN", lan_addr[0].str, runtime_vars.port, detailID);
+					                       mime, "DLNA.ORG_PN=JPEG_TN;DLNA.ORG_CI=1;DLNA.ORG_FLAGS=01500000000000000000000000000000", lan_addr[0].str, runtime_vars.port, detailID);
 					memcpy(passed_args->resp+passed_args->size, &str_buf, ret+1);
 					passed_args->size += ret;
 				}
+			}
+		}
+
+                /* additional <res>-tags for thumbnails, etc. */
+		if( album_art && atoi(album_art) )
+		{
+			/* Video and audio album art is handled differently */
+			if( *mime == 'v' && (passed_args->filter & FILTER_RES) && (passed_args->client != EXbox) ) {
+				ret = sprintf(str_buf, "&lt;res protocolInfo=\"http-get:*:image/jpeg:DLNA.ORG_PN=JPEG_TN;DLNA.ORG_CI=1;DLNA.ORG_FLAGS=00D00000000000000000000000000000\"&gt;"
+				                       "http://%s:%d/AlbumArt/%s-%s.jpg"
+				                       "&lt;/res&gt;",
+				                       lan_addr[0].str, runtime_vars.port, album_art, detailID);
+				memcpy(passed_args->resp+passed_args->size, &str_buf, ret+1);
+				passed_args->size += ret;
+                                if (passed_args->client == ESamsungTV) {
+                                    ret = sprintf(str_buf, "&lt;res protocolInfo=\"http-get:*:image/jpeg:DLNA.ORG_PN=JPEG_SM;DLNA.ORG_CI=1;DLNA.ORG_FLAGS=00D00000000000000000000000000000\"&gt;"
+                                                           "http://%s:%d/AlbumArt/%s-%s.jpg"
+				                           "&lt;/res&gt;",
+				                           lan_addr[0].str, runtime_vars.port, album_art, detailID);
+                                    memcpy(passed_args->resp+passed_args->size, &str_buf, ret+1);
+                                    passed_args->size += ret;
+                                }
+			}
+			else if( passed_args->filter & FILTER_UPNP_ALBUMARTURI ) {
+				ret = sprintf(str_buf, "&lt;upnp:albumArtURI ");
+				memcpy(passed_args->resp+passed_args->size, &str_buf, ret+1);
+				passed_args->size += ret;
+				if( passed_args->filter & FILTER_UPNP_ALBUMARTURI_DLNA_PROFILEID ) {
+					ret = sprintf(str_buf, "dlna:profileID=\"%s\" xmlns:dlna=\"urn:schemas-dlna-org:metadata-1-0/\"", "JPEG_TN");
+					memcpy(passed_args->resp+passed_args->size, &str_buf, ret+1);
+					passed_args->size += ret;
+				}
+				ret = sprintf(str_buf, "&gt;http://%s:%d/AlbumArt/%s-%s.jpg&lt;/upnp:albumArtURI&gt;",
+						 lan_addr[0].str, runtime_vars.port, album_art, detailID);
+				memcpy(passed_args->resp+passed_args->size, &str_buf, ret+1);
+				passed_args->size += ret;
 			}
 		}
 		ret = sprintf(str_buf, "&lt;/item&gt;");
@@ -816,7 +891,7 @@ callback(void *args, int argc, char **argv, char **azColName)
 		ret = snprintf(str_buf, 512, "&gt;"
 		                             "&lt;dc:title&gt;%s&lt;/dc:title&gt;"
 		                             "&lt;upnp:class&gt;object.%s&lt;/upnp:class&gt;",
-		                             title, class);
+                               title, (passed_args->client == ESamsungTV?"container":class));
 		memcpy(passed_args->resp+passed_args->size, &str_buf, ret+1);
 		passed_args->size += ret;
 		if( creator && (passed_args->filter & FILTER_DC_CREATOR) ) {
@@ -886,7 +961,7 @@ BrowseContentDirectory(struct upnphttp * h, const char * action)
 	int StartingIndex = 0;
 	if( (ptr = GetValueFromNameValueList(&data, "RequestedCount")) )
 		RequestedCount = atoi(ptr);
-	if( !RequestedCount )
+	if( !RequestedCount)
 		RequestedCount = -1;
 	if( (ptr = GetValueFromNameValueList(&data, "StartingIndex")) )
 		StartingIndex = atoi(ptr);
@@ -914,12 +989,17 @@ BrowseContentDirectory(struct upnphttp * h, const char * action)
 	args.size = sprintf(resp, "%s", resp0);
 	/* See if we need to include DLNA namespace reference */
 	args.filter = set_filter_flags(Filter);
-	if( args.filter & FILTER_DLNA_NAMESPACE )
+	if( args.filter & FILTER_DLNA_NAMESPACE || h->req_client == ESamsungTV )
 	{
 		ret = sprintf(str_buf, DLNA_NAMESPACE);
 		memcpy(resp+args.size, &str_buf, ret+1);
 		args.size += ret;
 	}
+        if (h->req_client == ESamsungTV ) {
+            ret = sprintf(str_buf, SEC_NAMESPACE);
+            memcpy(resp+args.size, &str_buf, ret+1);
+            args.size += ret;
+        }
 	ret = sprintf(str_buf, "&gt;\n");
 	memcpy(resp+args.size, &str_buf, ret+1);
 	args.size += ret;
@@ -937,6 +1017,11 @@ BrowseContentDirectory(struct upnphttp * h, const char * action)
 		else
 			ObjectId = strdup(ObjectId);
 	}
+        if (h->req_client == ESamsungTV )
+	{
+		if( strcmp(ObjectId, "V_T") == 0 )
+			ObjectId = strdup(VIDEO_DIR_ID);
+	}
 	DPRINTF(E_DEBUG, L_HTTP, "Browsing ContentDirectory:\n"
 	                         " * ObjectID: %s\n"
 	                         " * Count: %d\n"
@@ -947,17 +1032,37 @@ BrowseContentDirectory(struct upnphttp * h, const char * action)
 				ObjectId, RequestedCount, StartingIndex,
 	                        BrowseFlag, Filter, SortCriteria);
 
-	if( strcmp(BrowseFlag+6, "Metadata") == 0 )
+        if ( args.client == ESamsungTV && !StartingIndex &&
+             RequestedCount == -1/* && args.filter == FILTER_PARENT_ID*/ ) {
+                /* Samsung tries to search @parentID only */
+                char *parentID = strdup(ObjectId);
+                char *pos = rindex(ObjectId, '$');
+                if (pos)
+                    *pos=0;
+
+		sql = sqlite3_mprintf( SELECT_COLUMNS
+		                      "from OBJECTS o left join DETAILS d on (d.ID = o.DETAIL_ID)"
+		                      " left join CAPTIONS c on (c.ID = o.DETAIL_ID)"
+				      " where OBJECT_ID = '%s' %s limit %d, %d;",
+				      parentID, orderBy, StartingIndex, StartingIndex+1);
+		DPRINTF(E_DEBUG, L_HTTP, "Browse SQL: %s\n", sql);
+		ret = sqlite3_exec(db, sql, callback, (void *) &args, &zErrMsg);
+
+		totalMatches = args.returned;
+                free(parentID);
+        }
+        else if( strcmp(BrowseFlag+6, "Metadata") == 0 )
 	{
 		args.requested = 1;
 		sql = sqlite3_mprintf( SELECT_COLUMNS
-		                      "from OBJECTS o left join DETAILS d on (d.ID = o.DETAIL_ID)"
-		                      " where OBJECT_ID = '%s';"
-		                      , ObjectId);
+	                      "from OBJECTS o left join DETAILS d on (d.ID = o.DETAIL_ID)"
+	                      " left join CAPTIONS c on (c.ID = o.DETAIL_ID)"
+	                      " where OBJECT_ID = '%s';"
+	                      , ObjectId);
 		ret = sqlite3_exec(db, sql, callback, (void *) &args, &zErrMsg);
 		totalMatches = args.returned;
 	}
-	else
+        else
 	{
 		ret = sql_get_int_field(db, "SELECT count(*) from OBJECTS where PARENT_ID = '%s'", ObjectId);
 		totalMatches = (ret > 0) ? ret : 0;
@@ -988,16 +1093,19 @@ BrowseContentDirectory(struct upnphttp * h, const char * action)
 
 		sql = sqlite3_mprintf( SELECT_COLUMNS
 		                      "from OBJECTS o left join DETAILS d on (d.ID = o.DETAIL_ID)"
+		                      " left join CAPTIONS c on (c.ID = o.DETAIL_ID)"
 				      " where PARENT_ID = '%s' %s limit %d, %d;",
 				      ObjectId, orderBy, StartingIndex, RequestedCount);
 		DPRINTF(E_DEBUG, L_HTTP, "Browse SQL: %s\n", sql);
 		ret = sqlite3_exec(db, sql, callback, (void *) &args, &zErrMsg);
 	}
-	sqlite3_free(sql);
-	if( (ret != SQLITE_OK) && (zErrMsg != NULL) )
-	{
-		DPRINTF(E_WARN, L_HTTP, "SQL error: %s\nBAD SQL: %s\n", zErrMsg, sql);
-		sqlite3_free(zErrMsg);
+	if (sql) {
+		sqlite3_free(sql);
+		if( (ret != SQLITE_OK) && (zErrMsg != NULL) )
+		{
+			DPRINTF(E_WARN, L_HTTP, "SQL error: %s\nBAD SQL: %s\n", zErrMsg, sql);
+			sqlite3_free(zErrMsg);
+		}
 	}
 	/* Does the object even exist? */
 	if( !totalMatches )
@@ -1080,12 +1188,17 @@ SearchContentDirectory(struct upnphttp * h, const char * action)
 	args.size = sprintf(resp, "%s", resp0);
 	/* See if we need to include DLNA namespace reference */
 	args.filter = set_filter_flags(Filter);
-	if( args.filter & FILTER_DLNA_NAMESPACE )
+	if( args.filter & FILTER_DLNA_NAMESPACE || h->req_client == ESamsungTV )
 	{
 		ret = sprintf(str_buf, DLNA_NAMESPACE);
 		memcpy(resp+args.size, &str_buf, ret+1);
 		args.size += ret;
 	}
+        if ( h->req_client == ESamsungTV ) {
+            ret = sprintf(str_buf, SEC_NAMESPACE);
+            memcpy(resp+args.size, &str_buf, ret+1);
+            args.size += ret;
+        }
 	ret = sprintf(str_buf, "&gt;\n");
 	memcpy(resp+args.size, &str_buf, ret+1);
 	args.size += ret;
@@ -1227,6 +1340,7 @@ SearchContentDirectory(struct upnphttp * h, const char * action)
 
 	sql = sqlite3_mprintf( SELECT_COLUMNS
 	                      "from OBJECTS o left join DETAILS d on (d.ID = o.DETAIL_ID)"
+	                      " left join CAPTIONS c on (c.ID = o.DETAIL_ID)"
 	                      " where OBJECT_ID glob '%s$*' and (%s) %s "
 	                      "%z %s"
 	                      " limit %d, %d",
@@ -1234,6 +1348,7 @@ SearchContentDirectory(struct upnphttp * h, const char * action)
 	                      (*ContainerID == '*') ? NULL :
                               sqlite3_mprintf("UNION ALL " SELECT_COLUMNS
 	                                      "from OBJECTS o left join DETAILS d on (d.ID = o.DETAIL_ID)"
+                                              " left join CAPTIONS c on (c.ID = o.DETAIL_ID)"
 	                                      " where OBJECT_ID = '%s' and (%s) ", ContainerID, SearchCriteria),
 	                      orderBy, StartingIndex, RequestedCount);
 	DPRINTF(E_DEBUG, L_HTTP, "Search SQL: %s\n", sql);
@@ -1316,6 +1431,82 @@ QueryStateVariable(struct upnphttp * h, const char * action)
 	ClearNameValueList(&data);	
 }
 
+
+static void
+SamsungGetFeatureList(struct upnphttp * h, const char * action)
+{
+	static const char resp[] =
+		"<u:X_GetFeatureListResponse xmlns:u=\"urn:schemas-upnp-org:service:ContentDirectory:1\">"
+		"<FeatureList>"
+		"&lt;?xml version=&quot;1.0&quot; encoding=&quot;UTF-8&quot;?&gt;"
+		"&lt;Features xmlns=&quot;urn:schemas-upnp-org:av:avs&quot; "
+		  "xmlns:xsi=&quot;http://www.w3.org/2001/XMLSchema-instance&quot; "
+		  "xsi:schemaLocation=&quot; urn:schemas-upnp-org:av:avs "
+		  "http://www.upnp.org/schemas/av/avs.xsd&quot;&gt;"
+		"&lt;Feature name=&quot;samsung.com_BASICVIEW&quot; version=&quot;1&quot;&gt;"
+		"&lt;container id=&quot;2&quot; type=&quot;object.item.videoItem&quot;/&gt;"
+		"&lt;container id=&quot;1&quot; type=&quot;object.item.audioItem&quot;/&gt;"
+		"&lt;container id=&quot;3&quot; type=&quot;object.item.imageItem&quot;/&gt;"
+		"&lt;/Feature&gt;"
+		"&lt;Feature name=&quot;samsung.com_DCMVIEW&quot; version=&quot;1&quot;&gt;"
+/*		"&lt;container id=&quot;I_M&quot; type=&quot;IMAGE_Monthly&quot;/&gt;" */
+/*		"&lt;container id=&quot;I_C&quot; type=&quot;IMAGE_Color&quot;/&gt;" */
+		"&lt;container id=&quot;3$12&quot; type=&quot;IMAGE_Timeline&quot;/&gt;"
+/*		"&lt;container id=&quot;I_P&quot; type=&quot;IMAGE_Composition&quot;/&gt;" */
+                "&lt;container id=&quot;" IMAGE_DIR_ID "&quot; type=&quot;IMAGE_Folder&quot;/&gt;"
+		"&lt;container id=&quot;3$11&quot; type=&quot;IMAGE_Title&quot;/&gt;"
+/*		"&lt;container id=&quot;I_L&quot; type=&quot;IMAGE_LatestDate&quot;/&gt;" */
+/*		"&lt;container id=&quot;I_E&quot; type=&quot;IMAGE_EarliestDate&quot;/&gt;" */
+		"&lt;container id=&quot;1$5&quot; type=&quot;AUDIO_Genre&quot;/&gt;"
+		"&lt;container id=&quot;1$6&quot; type=&quot;AUDIO_Artist&quot;/&gt;"
+		"&lt;container id=&quot;" MUSIC_DIR_ID "&quot; type=&quot;AUDIO_Folder&quot;/&gt;"
+/*		"&lt;container id=&quot;A_M&quot; type=&quot;AUDIO_Mood&quot;/&gt;" */
+		"&lt;container id=&quot;1$4&quot; type=&quot;AUDIO_Title&quot;/&gt;"
+		"&lt;container id=&quot;1$7&quot; type=&quot;AUDIO_Album&quot;/&gt;"
+		"&lt;container id=&quot;2$8&quot; type=&quot;VIDEO_Title&quot;/&gt;"
+/*		"&lt;container id=&quot;V_D&quot; type=&quot;VIDEO_Date&quot;/&gt;" */
+		"&lt;container id=&quot;" VIDEO_DIR_ID "&quot; type=&quot;VIDEO_Folder&quot;/&gt;"
+/*		"&lt;container id=&quot;V_L&quot; type=&quot;VIDEO_LatestDate&quot;/&gt;" */
+/*		"&lt;container id=&quot;V_E&quot; type=&quot;VIDEO_EarliestDate&quot;/&gt;" */
+		"&lt;/Feature&gt;"
+		"&lt;/Features&gt;"
+		"</FeatureList></u:X_GetFeatureListResponse>";
+
+	char body[4096];
+	int bodylen;
+
+	bodylen = snprintf(body, sizeof(body), resp);
+	BuildSendAndCloseSoapResp(h, body, bodylen);
+}
+
+static void
+SamsungSetBookmark(struct upnphttp * h, const char * action)
+{
+	static const char resp[] =
+            "<s:Envelope xmlns:s=\"http://schemas.xmlsoap.org/soap/envelope/\""
+            " s:encodingStyle=\"http://schemas.xmlsoap.org/soap/encoding/\">"
+            "<s:Body><u:X_SetBookmarkResponse"
+            " xmlns:u=\"urn:schemas-upnp-org:service:ContentDirectory:1\">"
+            "</u:X_SetBookmarkResponse></s:Body></s:Envelope>";
+
+	char body[512];
+	int bodylen;
+	struct NameValueParserData data;
+
+	ParseNameValue(h->req_buf + h->req_contentoff, h->req_contentlen, &data);
+	char* ObjectID  = GetValueFromNameValueList(&data, "ObjectID");
+	char* PosSecond = GetValueFromNameValueList(&data, "PosSecond");
+        if (!atoi(PosSecond))
+            PosSecond="";
+
+        /* store Bookmark into OBJECTS */
+        if( sql_exec(db, "UPDATE OBJECTS set BOOKMARK = %d where OBJECT_ID='%s'", atoi(PosSecond), ObjectID) != SQLITE_OK )
+            DPRINTF(E_WARN, L_METADATA, "Error setting bookmark %d on objectId='%s'\n", atoi(PosSecond), ObjectID);
+
+	bodylen = snprintf(body, sizeof(body), resp);
+	BuildSendAndCloseSoapResp(h, body, bodylen);
+}
+
 static const struct 
 {
 	const char * methodName; 
@@ -1334,6 +1525,8 @@ soapMethods[] =
 	{ "GetCurrentConnectionInfo", GetCurrentConnectionInfo},
 	{ "IsAuthorized", IsAuthorizedValidated},
 	{ "IsValidated", IsAuthorizedValidated},
+	{ "X_GetFeatureList", SamsungGetFeatureList},
+	{ "X_SetBookmark", SamsungSetBookmark},
 	{ 0, 0 }
 };
 

--- a/upnpsoap.h
+++ b/upnpsoap.h
@@ -11,9 +11,11 @@
 #define MAX_RESPONSE_SIZE 1048576
 
 #define CONTENT_DIRECTORY_SCHEMAS \
+	" xmlns=\"urn:schemas-upnp-org:metadata-1-0/DIDL-Lite/\"" \
 	" xmlns:dc=\"http://purl.org/dc/elements/1.1/\"" \
-	" xmlns:upnp=\"urn:schemas-upnp-org:metadata-1-0/upnp/\"" \
-	" xmlns=\"urn:schemas-upnp-org:metadata-1-0/DIDL-Lite/\""
+	" xmlns:upnp= &apos;urn:schemas-upnp-org:metadata-1-0/upnp/&apos;"
+#define SEC_NAMESPACE \
+	" xmlns:sec=\"http://www.sec.co.kr/\""
 #define DLNA_NAMESPACE \
 	" xmlns:dlna=\"urn:schemas-dlna-org:metadata-1-0/\""
 


### PR DESCRIPTION
This patch will enable miniDLNA using to support most features of a
Samsung LE40C650 LCD TV:

* thumbnails (patch from minidlna forum which produces jpeg thumbnails
  e.g. movie.avi.jpg)
* subtitle submenu, if external subtitles are found
* chapter selection (every 10% of the movie)
* Bookmarks (jump to last watched position)

However, there are still some risks involved:

* Switching to any different sort order than "basic" (blue "D"-Button on
  remote when in Video) will NOT work (TV freezes for about 90secs and
  stops media player)
* I have not tested against any other renderers. Though I tried to make
  every change specific to Samsung TVs, I cannot guarantee older
  Samsungs have Problems now.
* THIS IS STILL EARLY BETA (but I already use it)

(By 'RandomCore': https://sourceforge.net/p/minidlna/patches/12/)