### PR TITLE
uuid.c: add asm/unistd.h include to fix build with musl-1.2.0

### DIFF
--- a/uuid.c
+++ b/uuid.c
@@ -36,6 +36,7 @@
 #if HAVE_MACH_MACH_TIME_H
 #include <mach/mach_time.h>
 #elif HAVE_CLOCK_GETTIME_SYSCALL
+#include <asm/unistd.h>
 #include <sys/syscall.h>
 #endif
 


### PR DESCRIPTION
Build was broken due to musl commit
https://git.musl-libc.org/cgit/musl/commit/?id=5a105f19b5aae79dd302899e634b6b18b3dcd0d6

To fix also include asm/unistd.h following the configure.ac check for
the __NR_clock_gettime syscall.

Signed-off-by: Bernd Kuhls <bernd.kuhls@t-online.de>