### PR TITLE
New -I option to respond to nonlocal queries.

### DIFF
--- a/minidlna.c
+++ b/minidlna.c
@@ -584,6 +584,7 @@ init(int argc, char **argv)
 	runtime_vars.port = 8200;
 	runtime_vars.notify_interval = 895;	/* seconds between SSDP announces */
 	runtime_vars.max_connections = 50;
+	runtime_vars.nonlocal_iface = -1; /* don't respond to nonlocal queries */
 	runtime_vars.root_container = NULL;
 	runtime_vars.ifaces[0] = NULL;
 
@@ -897,6 +898,10 @@ init(int argc, char **argv)
 			}
 			else
 				DPRINTF(E_FATAL, L_GENERAL, "Option -%c takes one argument.\n", argv[i][1]);
+			break;
+		case 'I':
+			/* Respond to nonlocal queries from first interface */
+			runtime_vars.nonlocal_iface = 0;
 			break;
 		case 'f':
 			i++;	/* discarding, the config file is already read */

--- a/minidlnad.8
+++ b/minidlnad.8
@@ -51,6 +51,9 @@ Force minidlna to report a specific serial number.
 .IP "\fB\-t\fR \fInotify_interval\fR"
 Change the notify interval, in seconds. Defaults to 895 seconds.
 
+.IP "\fB-I\fR"
+Enable responses to queries from remote networks.
+
 .IP "\fB\-h\fR \fIhelp\fR"
 Show basic switch options for running minidlna.
 

--- a/minidlnatypes.h
+++ b/minidlnatypes.h
@@ -49,6 +49,7 @@ struct runtime_vars_s {
 	int port;	/* HTTP Port */
 	int notify_interval;	/* seconds between SSDP announces */
 	int max_connections;	/* max number of simultaneous conenctions */
+	int nonlocal_iface;	/* iface to use respond to nonlocal queries */
 	const char *root_container;	/* root ObjectID (instead of "0") */
 	const char *ifaces[MAX_LAN_ADDR];	/* list of configured network interfaces */
 };

--- a/minissdp.c
+++ b/minissdp.c
@@ -694,9 +694,15 @@ ProcessSSDPRequest(struct event *ev)
 #endif
 			if (n_lan_addr == i)
 			{
-				DPRINTF(E_DEBUG, L_SSDP, "Ignoring SSDP M-SEARCH on other interface [%s]\n",
-					inet_ntoa(sendername.sin_addr));
-				return;
+				if (runtime_vars.nonlocal_iface >= 0) {
+					i = runtime_vars.nonlocal_iface;
+				}
+				else
+				{
+					DPRINTF(E_DEBUG, L_SSDP, "Ignoring SSDP M-SEARCH on other interface [%s]\n",
+						inet_ntoa(sendername.sin_addr));
+					return;
+				}
 			}
 			DPRINTF(E_DEBUG, L_SSDP, "SSDP M-SEARCH from %s:%d ST: %.*s, MX: %.*s, MAN: %.*s\n",
 				inet_ntoa(sendername.sin_addr),


### PR DESCRIPTION
This allows minidlna to serve clients on remote networks,
provided that suitable multicast routing and firewall rules
are in place.