### PR TITLE
Force sorting by path

### DIFF
--- a/upnpsoap.c
+++ b/upnpsoap.c
@@ -261,6 +261,7 @@ GetSortCapabilities(struct upnphttp * h, const char * action)
 		"<u:%sResponse "
 		"xmlns:u=\"%s\">"
 		"<SortCaps>"
+                  "path,"
 		  "dc:title,"
 		  "dc:date,"
 		  "upnp:class,"
@@ -641,6 +642,11 @@ parse_sort_criteria(char *sortCriteria, int *error)
 		{
 			strcatf(&str, "o.CLASS");
 		}
+                else if( strcasecmp(item, "path") == 0 )
+                {
+                        strcatf(&str, "d.PATH");
+                        title_sorted = 1;
+                }
 		else if( strcasecmp(item, "dc:title") == 0 )
 		{
 			strcatf(&str, "d.TITLE");


### PR DESCRIPTION
My Yamaha WXA-50 only sorts via title so the result is albums playing
in alphabetical order...

I found no other fix (using the FreeBSD ports version of minidlna) than
to add the sorting capability "path".

It's very easily accomplished with a few lines. I kept
`title_sorted = 1;` as sorting via path does that as well.

Hope you find it helpful.

(By Oliver PA: https://sourceforge.net/p/minidlna/patches/177/)