### PR TITLE
Adds support for manual (non-destructive) rescan through signals.

### DIFF
--- a/minidlna.c
+++ b/minidlna.c
@@ -212,6 +212,17 @@ sigusr1(int sig)
 }
 
 static void
+sigusr2(int sig)
+{
+	signal(sig, sigusr2);
+	DPRINTF(E_WARN, L_GENERAL, "received signal %d, manual rescan\n", sig);
+
+	if (!GETFLAG(SCANNING_MASK) &&
+	    !GETFLAG(RESCAN_MASK))
+		SETFLAG(RESCAN_MASK);
+}
+
+static void
 sighup(int sig)
 {
 	signal(sig, sighup);
@@ -912,6 +923,10 @@ init(int argc, char **argv)
 			if (system(buf) != 0)
 				DPRINTF(E_FATAL, L_GENERAL, "Failed to clean old file cache %s. EXITING\n", db_path);
 			break;
+		case 'U':
+			pid = process_check_if_running(pidfilename);
+			printf("Manual rescan for " SERVER_NAME " %s\n", (pid > 0 && !kill(pid, SIGUSR2)) ? "sent" : "failed");
+			exit(0);
 		case 'u':
 			if (i+1 != argc)
 			{
@@ -971,9 +986,9 @@ init(int argc, char **argv)
 			"\t\t[-t notify_interval] [-P pid_filename]\n"
 			"\t\t[-s serial] [-m model_number]\n"
 #ifdef __linux__
-			"\t\t[-w url] [-r] [-R] [-L] [-S] [-V] [-h]\n"
+			"\t\t[-w url] [-r] [-R] [-U] [-L] [-S] [-V] [-h]\n"
 #else
-			"\t\t[-w url] [-r] [-R] [-L] [-V] [-h]\n"
+			"\t\t[-w url] [-r] [-R] [-U] [-L] [-V] [-h]\n"
 #endif
 			"\nNotes:\n\tNotify interval is in seconds. Default is 895 seconds.\n"
 			"\tDefault pid file is %s.\n"
@@ -981,7 +996,8 @@ init(int argc, char **argv)
 			"\t-w sets the presentation url. Default is http address on port 80\n"
 			"\t-v enables verbose output\n"
 			"\t-h displays this text\n"
-			"\t-r forces a rescan\n"
+			"\t-r forces a rescan on startup\n"
+			"\t-U forces a rescan while " SERVER_NAME " is running. Use after -P\n"
 			"\t-R forces a rebuild\n"
 			"\t-L do not create playlists\n"
 #ifdef __linux__
@@ -1023,7 +1039,7 @@ init(int argc, char **argv)
 		DPRINTF(E_FATAL, L_GENERAL, "Failed to open log file '%s/" LOGFILE_NAME "': %s\n",
 			log_path, strerror(errno));
 
-	if (process_check_if_running(pidfilename) < 0)
+	if (process_check_if_running(pidfilename) > 0)
 		DPRINTF(E_FATAL, L_GENERAL, SERVER_NAME " is already running. EXITING.\n");
 
 	set_startup_time();
@@ -1048,6 +1064,7 @@ init(int argc, char **argv)
 	if (signal(SIGUSR2, SIG_IGN) == SIG_ERR)
 		DPRINTF(E_FATAL, L_GENERAL, "Failed to set %s handler. EXITING.\n", "SIGUSR2");
 	signal(SIGUSR1, &sigusr1);
+	signal(SIGUSR2, &sigusr2);
 	sa.sa_handler = process_handle_child_termination;
 	if (sigaction(SIGCHLD, &sa, NULL))
 		DPRINTF(E_FATAL, L_GENERAL, "Failed to set %s handler. EXITING.\n", "SIGCHLD");
@@ -1271,12 +1288,20 @@ main(int argc, char **argv)
 
 		if (GETFLAG(SCANNING_MASK) && kill(scanner_pid, 0) != 0) {
 			CLEARFLAG(SCANNING_MASK);
+			CLEARFLAG(RESCAN_MASK);
 			if (_get_dbtime() != lastdbtime)
 				updateID++;
 #ifdef HAVE_KQUEUE
 			av_register_all();
 			kqueue_monitor_start();
 #endif /* HAVE_KQUEUE */
+		}
+		if (GETFLAG(RESCAN_MASK) && !GETFLAG(SCANNING_MASK))
+		{
+			if (GETFLAG(MONITOR_MASK))
+				DPRINTF(E_WARN, L_GENERAL, "Waiting for inotify to finish.\n");
+			else
+				check_db(db, -1, &scanner_pid);
 		}
 
 		event_module.process(timeout);

--- a/process.c
+++ b/process.c
@@ -179,7 +179,7 @@ process_check_if_running(const char *fname)
 {
 	char buffer[64];
 	int pidfile;
-	pid_t pid;
+	pid_t pid = 0;
 
 	if(!fname || *fname == '\0')
 		return -1;
@@ -193,17 +193,13 @@ process_check_if_running(const char *fname)
 	{
 		if( (pid = atol(buffer)) > 0)
 		{
-			if(!kill(pid, 0))
-			{
-				close(pidfile);
-				return -2;
-			}
+			pid = !kill(pid, 0) ? pid : -2;
 		}
 	}
 
 	close(pidfile);
 
-	return 0;
+	return (int) pid;
 }
 
 void

--- a/upnpglobalvars.c
+++ b/upnpglobalvars.c
@@ -58,7 +58,7 @@
 time_t startup_time = 0;
 
 struct runtime_vars_s runtime_vars;
-uint32_t runtime_flags = INOTIFY_MASK | TIVO_BONJOUR_MASK | SUBTITLES_MASK;
+volatile uint32_t runtime_flags = INOTIFY_MASK | TIVO_BONJOUR_MASK | SUBTITLES_MASK;
 
 const char *pidfilename = "/var/run/minidlna/minidlna.pid";
 

--- a/upnpglobalvars.h
+++ b/upnpglobalvars.h
@@ -187,7 +187,7 @@ extern time_t startup_time;
 
 extern struct runtime_vars_s runtime_vars;
 /* runtime boolean flags */
-extern uint32_t runtime_flags;
+extern volatile uint32_t runtime_flags;
 #define INOTIFY_MASK          0x0001
 #define TIVO_MASK             0x0002
 #define DLNA_STRICT_MASK      0x0004
@@ -204,6 +204,7 @@ extern uint32_t runtime_flags;
 #define RESCAN_MASK           0x0200
 #define SUBTITLES_MASK        0x0400
 #define FORCE_ALPHASORT_MASK  0x0800
+#define MONITOR_MASK          0x1000
 
 #define SETFLAG(mask)	runtime_flags |= mask
 #define GETFLAG(mask)	(runtime_flags & mask)


### PR DESCRIPTION
> Now works with or without inotify. Add to job scheduler or script to automate rescan. Usage:
>
> minidlnad -P /path/to/pidfile -U
>
> Note: Path for pidfile is only required when not using default pidfile. When using
> -P, ordering is important and must be used before -U.