### PR TITLE
fastscan

### DIFF
--- a/metadata.c
+++ b/metadata.c
@@ -663,6 +663,90 @@ no_exifdata:
 	return ret;
 }
 
+#define META_LINES 16
+#define META_LINE_SIZE 512
+char meta[META_LINES][META_LINE_SIZE];
+char meta_path[PATH_MAX];
+char meta_dir[PATH_MAX];
+char path_dup[PATH_MAX];
+char path_dup1[PATH_MAX];
+
+char buf[META_LINE_SIZE];
+void checkNull(char* buf)
+{
+	if (buf[strlen(buf)-1] == '\n')
+	{
+	  buf[strlen(buf)-1] = '\0';
+	}
+}
+
+int64_t
+GetVideoMetadataLite(const char * path, char * name)
+{
+	struct stat file;
+	int ret;
+
+	sprintf(path_dup1, "%s", path);
+	sprintf(path_dup, "%s", path);
+	char *dir_end = memrchr(path_dup, '/', strlen(path_dup));
+	*dir_end = '\0';
+	DPRINTF(E_DEBUG, L_METADATA, "Dirpath...[%s]\n", path_dup);
+	if ( GETFLAG(META_MEDIA_MASK) )
+	{
+		sprintf(meta_path, "%s/.meta/%s", path_dup, basename(path_dup1));
+	}
+	else
+	{
+		sprintf(meta_path, "%s/meta%s", db_path, path_dup1);
+	}
+
+	if ( !GETFLAG(META_MASK) || (stat(meta_path, &file) != 0 ))
+	{
+		DPRINTF(E_DEBUG, L_METADATA, "Get actual meta: %s!\n", meta_path);
+
+		return GetVideoMetadata(path, name);
+	} else
+	{
+		DPRINTF(E_DEBUG, L_GENERAL, "Reading metadata file...[%s]\n", meta_path);
+
+		// Reading metadata file
+		FILE *metadata_ex_d = fopen(meta_path, "r");
+		if (metadata_ex_d)
+		{
+			int i;
+			for (i = 0; i < META_LINES; i++)
+		{
+			fgets(meta[i], META_LINE_SIZE, metadata_ex_d);
+			checkNull(meta[i]);
+		}
+		fclose(metadata_ex_d);
+
+		//DPRINTF(E_WARN, L_GENERAL, "param8(name) is [%s]\n", meta[8]);
+
+		long long int pi0 = strtoll(meta[0], NULL, 10);
+		long int pi1 = strtol(meta[1], NULL, 10);
+		long long int pi15 = strtoll(meta[15], NULL, 10);
+
+		ret = sql_exec(db, "INSERT into DETAILS"
+			" (PATH, SIZE, TIMESTAMP, DURATION, DATE, CHANNELS, BITRATE, SAMPLERATE, RESOLUTION,"
+			"  TITLE, CREATOR, ARTIST, GENRE, COMMENT, DLNA_PN, MIME, ALBUM_ART) "
+			"VALUES"
+			" (%Q, %lld, %ld, %Q, %Q, %Q, %Q, %Q, %Q, '%q', %Q, %Q, %Q, %Q, %Q, '%q', %lld);",
+			path, pi0, pi1, meta[2], meta[3], meta[4], meta[5], meta[6], meta[7], meta[8],
+			meta[9], meta[10], meta[11], meta[12], meta[13],
+			meta[14], pi15);
+
+		if( ret == SQLITE_OK )
+		{
+			ret = sqlite3_last_insert_rowid(db);
+			check_for_captions(path, ret);
+		}
+		return ret;
+        } else
+		return GetVideoMetadata(path, name);
+	}
+}
+
 int64_t
 GetVideoMetadata(const char *path, const char *name)
 {
@@ -1559,8 +1643,62 @@ video_no_dlna:
 	}
 	else
 	{
-		ret = sqlite3_last_insert_rowid(db);
-		check_for_captions(path, ret);
+		if ( GETFLAG(META_MASK) )
+		{
+			DPRINTF(E_DEBUG, L_METADATA, "Create metadata file...[%s]\n", path);
+
+			ret = sqlite3_last_insert_rowid(db);
+			check_for_captions(path, ret);
+
+			// Create metadata file
+			struct stat file_stat;
+
+			sprintf(path_dup, "%s", path);
+			char *dir_end = memrchr(path_dup, '/', strlen(path_dup));
+			*dir_end = '\0';
+			DPRINTF(E_DEBUG, L_METADATA, "Dirpath...[%s]\n", path_dup);
+
+			if ( GETFLAG(META_MEDIA_MASK) )
+			{
+				sprintf(meta_path, "%s/.meta/", path_dup);
+			}
+			else
+			{
+				sprintf(meta_path, "%s/meta%s", db_path, path_dup);
+			}
+			if ( stat(meta_path, &file_stat) != 0 )
+			{
+				//mkdir(meta_path, S_IRWXU|S_IRWXG|S_IRWXO);
+				make_dir(meta_path, S_IRWXU|S_IRWXG|S_IRWXO);
+				DPRINTF(E_DEBUG, L_METADATA, "Create metadata path...[%s]\n", meta_path);
+			}
+			sprintf(path_dup1, "%s", path);
+			if ( GETFLAG(META_MEDIA_MASK) )
+			{
+				sprintf(meta_path, "%s/.meta/%s",path_dup, basename(path_dup1));
+			}
+			else
+			{
+				sprintf(meta_path, "%s/meta%s", db_path, path_dup1);
+			}
+
+			DPRINTF(E_DEBUG, L_METADATA, "Create metadata file...[%s]\n", meta_path);
+
+			//umask(S_IREAD|S_IWRITE|S_IRGRP|S_IWGRP|S_IROTH|S_IWOTH);
+			FILE *metadata_ex_d = fopen(meta_path, "w");
+			DPRINTF(E_DEBUG, L_METADATA, "Opened metafile...\n");
+			if (metadata_ex_d)
+			{
+			    sprintf(buf, "%lld\n%ld\n%s\n%s\n%d\n%d\n%d\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n%lld\n", (long long)file.st_size,
+				file.st_mtime, m.duration, m.date, m.channels, m.bitrate, m.frequency, m.resolution, m.title,
+				m.creator, m.artist, m.genre, m.comment, m.dlna_pn,
+				m.mime, album_art);
+			    fwrite(&buf, 1, strlen(buf), metadata_ex_d);
+			    fclose(metadata_ex_d);
+			    DPRINTF(E_DEBUG, L_METADATA, "Updated metadata file...[%s]\n", meta_path);
+			} else
+			    DPRINTF(E_WARN, L_METADATA, "Unable to create metadata file...[%s]\n", meta_path);
+		}
 	}
 	free_metadata(&m, free_flags);
 	free(path_cpy);

--- a/metadata.c
+++ b/metadata.c
@@ -725,7 +725,7 @@ GetVideoMetadataLite(const char * path, char * name)
 
 		long long int pi0 = strtoll(meta[0], NULL, 10);
 		long int pi1 = strtol(meta[1], NULL, 10);
-		long long int pi15 = strtoll(meta[15], NULL, 10);
+		long long int pi15 = find_album_art(path, 0, 0);
 
 		ret = sql_exec(db, "INSERT into DETAILS"
 			" (PATH, SIZE, TIMESTAMP, DURATION, DATE, CHANNELS, BITRATE, SAMPLERATE, RESOLUTION,"

--- a/metadata.h
+++ b/metadata.h
@@ -100,4 +100,7 @@ GetImageMetadata(const char *path, const char *name);
 int64_t
 GetVideoMetadata(const char *path, const char *name);
 
+int64_t
+GetVideoMetadataLite(const char * path, char * name);
+
 #endif

--- a/minidlna.c
+++ b/minidlna.c
@@ -752,6 +752,14 @@ init(int argc, char **argv)
 			if (strcasecmp(ary_options[i].value, "beacon") == 0)
 				CLEARFLAG(TIVO_BONJOUR_MASK);
 			break;
+		case META_KEEP:
+			if (strtobool(ary_options[i].value))
+				SETFLAG(META_MASK);
+			break;
+		case META_KEEP_MEDIA:
+			if (strtobool(ary_options[i].value))
+				SETFLAG(META_MEDIA_MASK);
+			break;
 		default:
 			DPRINTF(E_ERROR, L_GENERAL, "Unknown option in file %s\n",
 				optionsfile);

--- a/minidlna.conf
+++ b/minidlna.conf
@@ -88,3 +88,10 @@ model_number=1
 
 # set this to yes to allow symlinks that point outside user-defined media_dirs.
 #wide_links=no
+
+# keep metadata to allow for fast rebuilding of the database
+keep_metadata=no
+
+# keep the metadata in the folder .meta next to the media otherwise store in the cache directory
+# this is useful if you have removable disks containing your media
+keep_metadata_with_media=no

--- a/options.c
+++ b/options.c
@@ -67,6 +67,8 @@ static const struct {
 	{ MERGE_MEDIA_DIRS, "merge_media_dirs" },
 	{ WIDE_LINKS, "wide_links" },
 	{ TIVO_DISCOVERY, "tivo_discovery" },
+	{ META_KEEP, "keep_metadata" },
+	{ META_KEEP_MEDIA, "keep_metadata_with_media" },
 };
 
 int

--- a/options.h
+++ b/options.h
@@ -60,6 +60,8 @@ enum upnpconfigoptions {
 	MERGE_MEDIA_DIRS,		/* don't add an extra directory level when there are multiple media dirs */
 	WIDE_LINKS,			/* allow following symlinks outside the defined media_dirs */
 	TIVO_DISCOVERY,			/* TiVo discovery protocol: bonjour or beacon. Defaults to bonjour if supported */
+	META_KEEP,			/* keep metadata for fast rebuilding of the database */
+	META_KEEP_MEDIA, 		/* keep the metadata with the media in a .meta folder */
 };
 
 /* readoptionsfile()

--- a/scanner.c
+++ b/scanner.c
@@ -470,7 +470,7 @@ insert_file(const char *name, const char *path, const char *parentID, int object
 	{
 		strcpy(base, VIDEO_DIR_ID);
 		class = "item.videoItem";
-		detailID = GetVideoMetadata(path, name);
+		detailID = GetVideoMetadataLite(path, name);
 	}
 	else if( mtype == TYPE_PLAYLIST && (types & TYPE_PLAYLIST) )
 	{

--- a/upnpglobalvars.h
+++ b/upnpglobalvars.h
@@ -195,6 +195,8 @@ extern uint32_t runtime_flags;
 #endif
 #define SCANNING_MASK         0x0100
 #define RESCAN_MASK           0x0200
+#define META_MASK             0x0400
+#define META_MEDIA_MASK       0x0800
 
 #define SETFLAG(mask)	runtime_flags |= mask
 #define GETFLAG(mask)	(runtime_flags & mask)


### PR DESCRIPTION
> I have updated the fastscan fork diff and added a few config options
> to define if you want the meta data to be stored in the db_dir or in
> a .meta folder with the media - this allows for removeable media to
> be rescanned quickly.

~ Ian McFarlane (https://sourceforge.net/p/minidlna/patches/165/)

> Please find attached my adoption of that fastscan patch for the
> currenct readymedia version 1.2.1.
>
> Are there any plans to merge that feature to regular releases?

~ 'Logan007' (https://sourceforge.net/p/minidlna/patches/165/)

> P.S. The first version mixes up movies' icon references in the
> database when rescanned (after a previous incomplete scan or rescan).
> The new version "fixed-icons" gets it right - at least for thumbnails
> stored as seperate files next to the movies, it does not dig into the
> media files in search for album art. In my use case, this still
> remains a fast scan.

~ 'Logan007' (https://sourceforge.net/p/minidlna/patches/165/)