### PR TITLE
fulltext album search

### DIFF
--- a/inotify.c
+++ b/inotify.c
@@ -358,6 +358,8 @@ inotify_insert_file(char * name, const char * path)
 	if( stat(path, &st) != 0 )
 		return -1;
 
+	bk_destroy_bktable();
+
 	ts = sql_get_int_field(db, "SELECT TIMESTAMP from DETAILS where PATH = '%q'", path);
 	if( !ts && is_playlist(path) && (sql_get_int_field(db, "SELECT ID from PLAYLISTS where PATH = '%q'", path) > 0) )
 	{
@@ -549,6 +551,7 @@ inotify_remove_file(const char * path)
 	id = sql_get_text_field(db, "SELECT ID from %s where PATH = '%q'", playlist?"PLAYLISTS":"DETAILS", path);
 	if( !id )
 		return 1;
+	bk_destroy_bktable();
 	detailID = strtoll(id, NULL, 10);
 	sqlite3_free(id);
 	if( playlist )
@@ -613,6 +616,8 @@ inotify_remove_directory(int fd, const char * path)
 	char **result;
 	int64_t detailID = 0;
 	int rows, i, ret = 1;
+
+	bk_destroy_bktable();
 
 	/* Invalidate the scanner cache so we don't insert files into non-existent containers */
 	valid_cache = 0;

--- a/minidlna.c
+++ b/minidlna.c
@@ -275,6 +275,8 @@ open_db(sqlite3 **sq3)
 	sql_exec(db, "pragma journal_mode = OFF");
 	sql_exec(db, "pragma synchronous = OFF;");
 	sql_exec(db, "pragma default_cache_size = 8192;");
+	bk_bktable_exists = sql_get_int_field(db, "SELECT count(name) FROM sqlite_master WHERE type='table' AND name='bk'");
+	DPRINTF(E_WARN, L_GENERAL, "bktable_exists = %d\n", bk_bktable_exists);
 
 	return new_db;
 }

--- a/scanner.h
+++ b/scanner.h
@@ -83,4 +83,7 @@ CreateDatabase(void);
 void
 start_scanner();
 
+void bk_destroy_bktable(void);
+extern int bk_bktable_exists;
+
 #endif


### PR DESCRIPTION
> Below is a patch which implements fulltext search as described
> here.
>
> Implementation is a bit of a hack and should be improved by someone
> more knowledgeable about dlna than me. But it works, at least with
> BubbleUPNP and with the Denon client.
>
> When searching for a string, the matching albums are not only those
> whose title contains the string: an album matches as soon as each
> word of the string is contained in the title or artist name of some
> track or of the album (different words may appear in different
> places; typically, if you search for Mozart piano you want an album
> to match if Mozart is in the title or artist name of the album and
> piano is in the title of some track).
>
> In addition, diacritics are ignored.

~ Brett Kerwin (https://sourceforge.net/p/minidlna/patches/163/)