### PR TITLE
Prepend disc and track (season and ep) numbers to titles

### DIFF
--- a/metadata.c
+++ b/metadata.c
@@ -180,6 +180,9 @@ parse_nfo(const char *path, metadata_t *m)
 	
 	ParseNameValue(buf, nread, &xml, 0);
 
+	m->track = UINT_MAX;
+	m->disc  = UINT_MAX;
+
 	//printf("\ttype: %s\n", GetValueFromNameValueList(&xml, "rootElement"));
 	val = GetValueFromNameValueList(&xml, "title");
 	if( val )
@@ -194,6 +197,28 @@ parse_nfo(const char *path, metadata_t *m)
 		m->title = escape_tag(esc_tag, 1);
 		free(esc_tag);
 		free(title);
+	}
+
+	val = GetValueFromNameValueList(&xml, "episode");
+	if( val ) {
+		unsigned long ep;
+		char *esc_tag = unescape_tag(val, 1);
+		ep = strtoul(esc_tag, NULL, 0);
+		if (ep != 0 && ep < UINT_MAX) {
+			m->track = ep;
+		}
+		free(esc_tag);
+	}
+
+	val = GetValueFromNameValueList(&xml, "season");
+	if( val ) {
+		unsigned long season;
+		char *esc_tag = unescape_tag(val, 1);
+		season = strtoul(esc_tag, NULL, 0);
+		if (season != 0 && season < UINT_MAX) {
+			m->disc = season;
+		}
+		free(esc_tag);
 	}
 
 	val = GetValueFromNameValueList(&xml, "plot");
@@ -673,6 +698,7 @@ GetVideoMetadata(const char *path, char *name)
 	metadata_t m;
 	uint32_t free_flags = 0xFFFFFFFF;
 	char *path_cpy, *basepath;
+	char *disc, *track;
 
 	memset(&m, '\0', sizeof(m));
 	memset(&video, '\0', sizeof(video));
@@ -1541,15 +1567,27 @@ video_no_dlna:
 	freetags(&video);
 	lav_close(ctx);
 
+	disc  = malloc(12);
+	track = malloc(12);
+	if( m.disc > 0 && m.disc < UINT_MAX )
+		xasprintf(&disc, "%u", m.disc);
+	else
+		xasprintf(&disc, "NULL");
+
+	if( m.track > 0 && m.track < UINT_MAX )
+		xasprintf(&track, "%u", m.track);
+	else
+		xasprintf(&track, "NULL");
+
 	ret = sql_exec(db, "INSERT into DETAILS"
 	                   " (PATH, SIZE, TIMESTAMP, DURATION, DATE, CHANNELS, BITRATE, SAMPLERATE, RESOLUTION,"
-	                   "  TITLE, CREATOR, ARTIST, GENRE, COMMENT, DLNA_PN, MIME, ALBUM_ART) "
+	                   "  TITLE, CREATOR, ARTIST, GENRE, COMMENT, DLNA_PN, MIME, ALBUM_ART, DISC, TRACK) "
 	                   "VALUES"
-	                   " (%Q, %lld, %lld, %Q, %Q, %u, %u, %u, %Q, '%q', %Q, %Q, %Q, %Q, %Q, '%q', %lld);",
+	                   " (%Q, %lld, %lld, %Q, %Q, %u, %u, %u, %Q, '%q', %Q, %Q, %Q, %Q, %Q, '%q', %lld, %s, %s);",
 	                   path, (long long)file.st_size, (long long)file.st_mtime, m.duration,
 	                   m.date, m.channels, m.bitrate, m.frequency, m.resolution,
 			   m.title, m.creator, m.artist, m.genre, m.comment, m.dlna_pn,
-                           m.mime, album_art);
+                           m.mime, album_art, disc, track);
 	if( ret != SQLITE_OK )
 	{
 		DPRINTF(E_ERROR, L_METADATA, "Error inserting details for '%s'!\n", path);
@@ -1560,6 +1598,8 @@ video_no_dlna:
 		ret = sqlite3_last_insert_rowid(db);
 		check_for_captions(path, ret);
 	}
+	free(track);
+	free(disc);
 	free_metadata(&m, free_flags);
 	free(path_cpy);
 

--- a/minidlna.c
+++ b/minidlna.c
@@ -738,6 +738,14 @@ init(int argc, char **argv)
 			if (strtobool(ary_options[i].value))
 				SETFLAG(MERGE_MEDIA_DIRS_MASK);
 			break;
+		case PREPEND_TRACK_NUMBER:
+			if (strtobool(ary_options[i].value))
+				SETFLAG(PREPEND_TRACK_MASK);
+			break;
+		case PREPEND_DISC_NUMBER:
+			if (strtobool(ary_options[i].value))
+				SETFLAG(PREPEND_DISC_MASK);
+			break;
 		default:
 			DPRINTF(E_ERROR, L_GENERAL, "Unknown option in file %s\n",
 				optionsfile);

--- a/minidlna.conf
+++ b/minidlna.conf
@@ -81,3 +81,7 @@ model_number=1
 # maximum number of simultaneous connections
 # note: many clients open several simultaneous connections while streaming
 #max_connections=50
+
+# prepend disc and track numbers
+prepend_track_no=yes
+prepend_disc_no=yes

--- a/options.c
+++ b/options.c
@@ -64,7 +64,9 @@ static const struct {
 	{ USER_ACCOUNT, "user" },
 	{ FORCE_SORT_CRITERIA, "force_sort_criteria" },
 	{ MAX_CONNECTIONS, "max_connections" },
-	{ MERGE_MEDIA_DIRS, "merge_media_dirs" }
+	{ MERGE_MEDIA_DIRS, "merge_media_dirs" },
+	{ PREPEND_TRACK_NUMBER, "prepend_track_no" },
+	{ PREPEND_DISC_NUMBER, "prepend_disc_no" }
 };
 
 int

--- a/options.h
+++ b/options.h
@@ -57,7 +57,9 @@ enum upnpconfigoptions {
 	USER_ACCOUNT,			/* user account to run as */
 	FORCE_SORT_CRITERIA,		/* force sorting by a given sort criteria */
 	MAX_CONNECTIONS,		/* maximum number of simultaneous connections */
-	MERGE_MEDIA_DIRS		/* don't add an extra directory level when there are multiple media dirs */
+	MERGE_MEDIA_DIRS,		/* don't add an extra directory level when there are multiple media dirs */
+	PREPEND_TRACK_NUMBER,		/* prepend disc and track numbers */
+	PREPEND_DISC_NUMBER		/* to fix sorting on Samsung devices */
 };
 
 /* readoptionsfile()

--- a/upnpglobalvars.h
+++ b/upnpglobalvars.h
@@ -191,6 +191,8 @@ extern uint32_t runtime_flags;
 #define NO_PLAYLIST_MASK      0x0008
 #define SYSTEMD_MASK          0x0010
 #define MERGE_MEDIA_DIRS_MASK 0x0020
+#define PREPEND_TRACK_MASK    0x0040
+#define PREPEND_DISC_MASK     0x0080
 
 #define SETFLAG(mask)	runtime_flags |= mask
 #define GETFLAG(mask)	(runtime_flags & mask)


### PR DESCRIPTION
> I have 2 Samsung TVs (2012 & 2013) and they have very annoying
> problem: no matter what, they sort everything alphabetically. It
> simply means that all your music tracks, all your TV show episodes
> got sorted alphabetically, even if they have correct disc and track
> (season and episode) numbers set.
>
> So I've made this patch to fix this behaviour by simply prepending
> disc and track numbers to titles.
>
> It adds two boolean options to your config:
> - prepend_track_no
> - prepend_disc_no
>
> Just a quick sample: The Simpsons, Season 26. Both disabled:
> Clown in the Dumps
> Opposites A-Frack
> Super Franchise Me
> The Wreck of the Relationship
> Treehouse of Horror XXV
>
> With track_no enabled:
> 01. Clown in the Dumps
> 02. The Wreck of the Relationship
> 03. Super Franchise Me
> 04. Treehouse of Horror XXV
> 05. Opposites A-Frack
>
> With both disc_no and track_no enabled:
> 26x01. Clown in the Dumps
> 26x02. The Wreck of the Relationship
> 26x03. Super Franchise Me
> 26x04. Treehouse of Horror XXV
> 26x05. Opposites A-Frack
>
> Unfortunatelly to have TV show episode numbers you have to do a full
> rescan. You can enable and disable prepending later just by altering
> config, no rescan needed.
>
> Patch was made against clean 1.1.5 release, have to be a little bit
> redone for current.

~ 'nymous' (https://sourceforge.net/p/minidlna/patches/161/)