### PR TITLE
 Add option to send "standard" caption response 

### DIFF
--- a/minidlna.c
+++ b/minidlna.c
@@ -738,6 +738,13 @@ init(int argc, char **argv)
 			if (strtobool(ary_options[i].value))
 				SETFLAG(MERGE_MEDIA_DIRS_MASK);
 			break;
+		case FORCE_CAPTION_RESPONSE:
+			if( strtobool(ary_options[i].value) )
+			{
+				DPRINTF(E_WARN, L_GENERAL, "Using force caption response\n");
+				force_caption_response = 1;
+			}
+			break;
 		default:
 			DPRINTF(E_ERROR, L_GENERAL, "Unknown option in file %s\n",
 				optionsfile);

--- a/minidlna.conf
+++ b/minidlna.conf
@@ -81,3 +81,7 @@ model_number=1
 # maximum number of simultaneous connections
 # note: many clients open several simultaneous connections while streaming
 #max_connections=50
+
+# force sending "standard" caption response to clients
+#   For subtitles to actually work, the client will still need to support this response.
+#force_caption_response=yes

--- a/options.c
+++ b/options.c
@@ -64,7 +64,8 @@ static const struct {
 	{ USER_ACCOUNT, "user" },
 	{ FORCE_SORT_CRITERIA, "force_sort_criteria" },
 	{ MAX_CONNECTIONS, "max_connections" },
-	{ MERGE_MEDIA_DIRS, "merge_media_dirs" }
+	{ MERGE_MEDIA_DIRS, "merge_media_dirs" },
+	{ FORCE_CAPTION_RESPONSE, "force_caption_response" }
 };
 
 int

--- a/options.h
+++ b/options.h
@@ -57,7 +57,8 @@ enum upnpconfigoptions {
 	USER_ACCOUNT,			/* user account to run as */
 	FORCE_SORT_CRITERIA,		/* force sorting by a given sort criteria */
 	MAX_CONNECTIONS,		/* maximum number of simultaneous connections */
-	MERGE_MEDIA_DIRS		/* don't add an extra directory level when there are multiple media dirs */
+	MERGE_MEDIA_DIRS,		/* don't add an extra directory level when there are multiple media dirs */
+	FORCE_CAPTION_RESPONSE		/* force sending the caption response */
 };
 
 /* readoptionsfile()

--- a/upnpglobalvars.c
+++ b/upnpglobalvars.c
@@ -92,3 +92,4 @@ short int scanning = 0;
 volatile short int quitting = 0;
 volatile uint32_t updateID = 0;
 const char *force_sort_criteria = NULL;
+short int force_caption_response = 0;

--- a/upnpglobalvars.h
+++ b/upnpglobalvars.h
@@ -235,5 +235,6 @@ extern short int scanning;
 extern volatile short int quitting;
 extern volatile uint32_t updateID;
 extern const char *force_sort_criteria;
+short int force_caption_response;
 
 #endif

--- a/upnpsoap.c
+++ b/upnpsoap.c
@@ -854,7 +854,7 @@ callback(void *args, int argc, char **argv, char **azColName)
 					strcpy(mime+6, "mpeg");
 				}
 			}
-			if( (passed_args->flags & FLAG_CAPTION_RES) ||
+			if( (force_caption_response || (passed_args->flags & FLAG_CAPTION_RES)) ||
 			    (passed_args->filter & (FILTER_SEC_CAPTION_INFO_EX|FILTER_PV_SUBTITLE)) )
 			{
 				if( sql_get_int_field(db, "SELECT ID from CAPTIONS where ID = '%s'", detailID) > 0 )
@@ -1057,24 +1057,24 @@ callback(void *args, int argc, char **argv, char **azColName)
 				case ELGDevice:
 				case EAsusOPlay:
 				default:
-					if( passed_args->flags & FLAG_HAS_CAPTIONS )
-					{
-						if( passed_args->flags & FLAG_CAPTION_RES )
-							ret = strcatf(str, "&lt;res protocolInfo=\"http-get:*:text/srt:*\"&gt;"
-									     "http://%s:%d/Captions/%s.srt"
-									   "&lt;/res&gt;",
-									   lan_addr[passed_args->iface].str, runtime_vars.port, detailID);
-						else if( passed_args->filter & FILTER_SEC_CAPTION_INFO_EX )
+						if( (passed_args->flags & FLAG_HAS_CAPTIONS) &&
+						    (passed_args->filter & FILTER_SEC_CAPTION_INFO_EX) )
 							ret = strcatf(str, "&lt;sec:CaptionInfoEx sec:type=\"srt\"&gt;"
-							                     "http://%s:%d/Captions/%s.srt"
+							                   "http://%s:%d/Captions/%s.srt"
 							                   "&lt;/sec:CaptionInfoEx&gt;",
 							                   lan_addr[passed_args->iface].str, runtime_vars.port, detailID);
-					}
 					free(alt_title);
 					break;
 				}
 			}
 		}
+		if( *mime == 'v' && (passed_args->flags & FLAG_HAS_CAPTIONS) &&
+		    (force_caption_response ||
+		    ((passed_args->filter & FILTER_RES) && (passed_args->flags & FLAG_CAPTION_RES))) )
+				ret = strcatf(str, "&lt;res protocolInfo=\"http-get:*:text/srt:*\"&gt;"
+				                   "http://%s:%d/Captions/%s.srt"
+				                   "&lt;/res&gt;",
+				                   lan_addr[passed_args->iface].str, runtime_vars.port, detailID);
 		if( NON_ZERO(album_art) )
 		{
 			/* Video and audio album art is handled differently */


### PR DESCRIPTION
> Adds force_caption_response to minidlna.conf. Users can force the "standard" caption response regardless of client type.
> 
> This or a similar feature might cut down the "add subtitle support for..." requests.
> 
> I only briefly tested this as I embed my subtitles.