### PR TITLE
incoming connection script support

### DIFF
--- a/clients.c
+++ b/clients.c
@@ -17,11 +17,14 @@
  */
 #include <stdio.h>
 #include <string.h>
+#include <stdlib.h>
 #include <time.h>
 
 #include "clients.h"
 #include "getifaddr.h"
 #include "log.h"
+#include "options.h"
+#include "upnpglobalvars.h"
 
 struct client_type_s client_types[] =
 {
@@ -293,6 +296,23 @@ AddClientCache(struct in_addr addr, int type)
 					client_types[type].name, inet_ntoa(clients[i].addr),
 					clients[i].mac[0], clients[i].mac[1], clients[i].mac[2],
 					clients[i].mac[3], clients[i].mac[4], clients[i].mac[5], i);
+
+		if (runtime_vars.on_connection)
+		{
+			static const char fmt[] = "CLIENT_ADDRESS=%s; %s";
+			char cmd[MAX_OPTION_VALUE_LEN + sizeof(fmt) * 2];
+			const int rc = snprintf(cmd,
+						sizeof(cmd),
+						fmt,
+						inet_ntoa(addr),
+						runtime_vars.on_connection
+					); /* sprintf cmd */
+			if (rc > 0 && rc < sizeof(cmd))
+			{
+				system(cmd);
+			}
+		}
+
 		return &clients[i];
 	}
 

--- a/minidlna.c
+++ b/minidlna.c
@@ -530,6 +530,7 @@ init(int argc, char **argv)
 	runtime_vars.port = 8200;
 	runtime_vars.notify_interval = 895;	/* seconds between SSDP announces */
 	runtime_vars.max_connections = 50;
+	runtime_vars.on_connection = NULL;
 	runtime_vars.root_container = NULL;
 	runtime_vars.ifaces[0] = NULL;
 
@@ -733,6 +734,10 @@ init(int argc, char **argv)
 			break;
 		case MAX_CONNECTIONS:
 			runtime_vars.max_connections = atoi(ary_options[i].value);
+			break;
+		case ON_CONNECTION:
+			if (ary_options[i].value && *ary_options[i].value)
+				runtime_vars.on_connection = ary_options[i].value;
 			break;
 		case MERGE_MEDIA_DIRS:
 			if (strtobool(ary_options[i].value))

--- a/minidlna.conf
+++ b/minidlna.conf
@@ -81,3 +81,8 @@ model_number=1
 # maximum number of simultaneous connections
 # note: many clients open several simultaneous connections while streaming
 #max_connections=50
+
+# shell command to be performed on client connection established.
+# the IP of client passed in variable CLIENT_ADDRESS
+# WARNING: be aware about blocking minidlna and use & at the command tail for heavy cases
+# on_connection=echo "incoming connection from $CLIENT_ADDRESS" >> /tmp/minidlna.clients.log

--- a/minidlnatypes.h
+++ b/minidlnatypes.h
@@ -49,6 +49,7 @@ struct runtime_vars_s {
 	int port;	/* HTTP Port */
 	int notify_interval;	/* seconds between SSDP announces */
 	int max_connections;	/* max number of simultaneous conenctions */
+	const char *on_connection;	/* script to be performed on new client acceptance */
 	const char *root_container;	/* root ObjectID (instead of "0") */
 	const char *ifaces[MAX_LAN_ADDR];	/* list of configured network interfaces */
 };

--- a/options.c
+++ b/options.c
@@ -64,6 +64,7 @@ static const struct {
 	{ USER_ACCOUNT, "user" },
 	{ FORCE_SORT_CRITERIA, "force_sort_criteria" },
 	{ MAX_CONNECTIONS, "max_connections" },
+	{ ON_CONNECTION, "on_connection" },
 	{ MERGE_MEDIA_DIRS, "merge_media_dirs" }
 };
 

--- a/options.h
+++ b/options.h
@@ -57,6 +57,7 @@ enum upnpconfigoptions {
 	USER_ACCOUNT,			/* user account to run as */
 	FORCE_SORT_CRITERIA,		/* force sorting by a given sort criteria */
 	MAX_CONNECTIONS,		/* maximum number of simultaneous connections */
+	ON_CONNECTION,			/* shell script to be executed on connection acceptance */
 	MERGE_MEDIA_DIRS		/* don't add an extra directory level when there are multiple media dirs */
 };
 


### PR DESCRIPTION
> On client incoming connection it is often required to do some minor operations e.g. wakeup disk array.
> Disabled by default.

https://sourceforge.net/p/minidlna/patches/154/